### PR TITLE
OSGi compatibility 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 						<Bundle-Category>${bundle.category}</Bundle-Category>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Version>${project.version}</Bundle-Version>
-						<Import-Package>org.eclipse.jetty.*;version="[7.2,8)",*</Import-Package>
+						<Import-Package>org.eclipse.jetty.*;version="[7.2,9)",*</Import-Package>
 						<mode>development</mode>
 						<url>${project.url}</url>
 						<implementation-version>${project.version}</implementation-version>


### PR DESCRIPTION
Hello,

Added maven-bundle-plugin ( http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html ) for basic OSGi compatibility (with broad version ranges for Jetty and javax.servlet).

Certain headers are required in META-INF/MANIFEST.MF for jars to be treated as OSGi bundles.  The maven-bundle-plugin adds necessary manifest entries for OSGi, specifically Import-Package and Export-Package (which determine module boundaries and mandate required versions) as well as non-essential informative entries (such as license details and vendor/contact info (dojofoundation.org)).

This is a small change that gives cometd OSGi support out-of-the-box, without affecting it's usage in other environments (the manifest entries originally specified in the maven-jar-plugin's config have been preserved in the maven-bundle-plugin).

All the tests pass and I'm using this fork happily in OSGi containers, it would be great to see this in an official release.

Thanks for developing/releasing cometd, it's great.

Best regards,
Caspar
