### PR TITLE
Support for AMD Loaders

### DIFF
--- a/cometd-javascript/common/src/main/js/org/cometd/cometd-namespace.js
+++ b/cometd-javascript/common/src/main/js/org/cometd/cometd-namespace.js
@@ -1,4 +1,4 @@
-if (typeof dojo !== 'undefined')
+if (typeof dojo !== 'undefined' && !dojo.isAsync)
 {
     dojo.provide('org.cometd');
 }
@@ -6,5 +6,11 @@ else
 {
     // Namespaces for the cometd implementation
     this.org = this.org || {};
-    org.cometd = {};
+	org.cometd = org.cometd || {};
+
+	if (typeof define === "function" && define.amd) {
+		define(function () {
+			return org.cometd;
+		});
+	}
 }

--- a/cometd-javascript/common/src/main/webapp/org/cometd/AckExtension.js
+++ b/cometd-javascript/common/src/main/webapp/org/cometd/AckExtension.js
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-if (typeof dojo!="undefined")
+if (typeof dojo !== 'undefined' && !dojo.isAsync)
 {
     dojo.provide("org.cometd.AckExtension");
+}
+else
+{
+	this.org = this.org || {};
+	org.cometd = org.cometd || {};
+
+	if (typeof define === "function" && define.amd) {
+		define(function () {
+			return org.cometd.AckExtension;
+		});
+	}
 }
 
 /**

--- a/cometd-javascript/common/src/main/webapp/org/cometd/ReloadExtension.js
+++ b/cometd-javascript/common/src/main/webapp/org/cometd/ReloadExtension.js
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-if (typeof dojo != 'undefined')
+if (typeof dojo !== 'undefined' && !dojo.isAsync)
 {
     dojo.provide('org.cometd.ReloadExtension');
+}
+else
+{
+	this.org = this.org || {};
+	org.cometd = org.cometd || {};
+
+	if (typeof define === "function" && define.amd) {
+		define(function () {
+			return org.cometd.ReloadExtension;
+		});
+	}
 }
 
 if (!org.cometd.COOKIE)

--- a/cometd-javascript/common/src/main/webapp/org/cometd/TimeStampExtension.js
+++ b/cometd-javascript/common/src/main/webapp/org/cometd/TimeStampExtension.js
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-if (typeof dojo != "undefined")
+if (typeof dojo !== 'undefined' && !dojo.isAsync)
 {
     dojo.provide("org.cometd.TimeStampExtension");
+}
+else
+{
+	this.org = this.org || {};
+	org.cometd = org.cometd || {};
+
+	if (typeof define === "function" && define.amd) {
+		define(function () {
+			return org.cometd.TimeStampExtension;
+		});
+	}
 }
 
 /**

--- a/cometd-javascript/common/src/main/webapp/org/cometd/TimeSyncExtension.js
+++ b/cometd-javascript/common/src/main/webapp/org/cometd/TimeSyncExtension.js
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-if (typeof dojo != "undefined")
+if (typeof dojo !== 'undefined' && !dojo.isAsync)
 {
     dojo.provide("org.cometd.TimeSyncExtension");
+}
+else
+{
+	this.org = this.org || {};
+	org.cometd = org.cometd || {};
+
+	if (typeof define === "function" && define.amd) {
+		define(function () {
+			return org.cometd.TimeSyncExtension;
+		});
+	}
 }
 
 /**


### PR DESCRIPTION
The OpenCoweb project (http://opencoweb.org/) has been using the cometd javascript in an AMD environment for a while now. We have been wrapping the code with a "define" call and it has been working fine. 

I saw in http://bugs.cometd.org/browse/COMETD-336 that there is plan to add AMD support. I thought I would put together a patch that enables AMD support while keeping backward compatibility. 

I have also strengthened the dojo provide check to make it more robust. That path should only be called when Dojo is being run in sync mode.

The AMD define call is only made if the AMD check passes :

if (typeof define === "function" && define.amd) 

I have also added AMD support to all the extensions too.

I should note that when I forked the cometd repo one of the tests was failing :

TEST-org.cometd.javascript.CometDWebSocketConnectTimeoutTest

I think it might be due to the fix for COMETD-343 as all the tests were passing about a week ago. 

My changes do not appear to break anything else
