### PR TITLE
downgrading to maven-jar-plugin 2.3.2 as 2.4 breaks eclipse integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
maven-jar-plugin 2.4 breaks the integration with Eclipse as described here

https://github.com/sonatype/m2eclipse-extras/issues/10
