### PR TITLE
Added Oort configuration via an external properties file and Oort automatic peers discovering AWS support

### DIFF
--- a/cometd-java/cometd-java-oort/pom.xml
+++ b/cometd-java/cometd-java-oort/pom.xml
@@ -75,6 +75,11 @@
             <version>${jackson-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+        	<groupId>com.amazonaws</groupId>
+        	<artifactId>aws-java-sdk</artifactId>
+        	<version>1.7.12</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfig.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+import java.util.Properties;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.common.JSONContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class OortConfig {
+	
+	private final Logger logger = LoggerFactory.getLogger(OortConfig.class);
+	
+    public static final String OORT_URL_PARAM = "oort.url";
+    public static final String OORT_CLIENT_DEBUG_PARAM = "clientDebug";
+    public static final String OORT_SECRET_PARAM = "oort.secret";
+    public static final String OORT_CHANNELS_PARAM = "oort.channels";
+    public static final String OORT_ENABLE_ACK_EXTENSION_PARAM = "enableAckExtension";
+    public static final String OORT_JSON_CONTEXT_PARAM = "jsonContext";
+
+    protected final Oort oort;
+    
+	public OortConfig(Properties properties, BayeuxServer bayeux) throws OortConfigException {
+        String url = properties.getProperty(OORT_URL_PARAM);
+        if (url == null) {
+        	throw new OortConfigException("OORT will not be enabled. Missing " + OORT_URL_PARAM + " init parameter");
+        }
+        	
+        try
+        {
+        	oort = new Oort(bayeux, url);
+
+            boolean clientDebug = Boolean.parseBoolean(properties.getProperty(OORT_CLIENT_DEBUG_PARAM));
+            oort.setClientDebugEnabled(clientDebug);
+
+            String secret = properties.getProperty(OORT_SECRET_PARAM, null);
+            if (secret != null)
+                oort.setSecret(secret);
+
+            boolean enableAckExtension = Boolean.parseBoolean(properties.getProperty(OORT_ENABLE_ACK_EXTENSION_PARAM));
+            oort.setAckExtensionEnabled(enableAckExtension);
+
+            String jsonContext = properties.getProperty(OORT_JSON_CONTEXT_PARAM);
+            if (jsonContext != null && !jsonContext.equals(""))
+                oort.setJSONContextClient((JSONContext.Client)getClass().getClassLoader().loadClass(jsonContext).newInstance());
+
+            oort.start();
+
+            String channels = properties.getProperty(OORT_CHANNELS_PARAM);
+            if (channels != null && !channels.equals(""))
+            {
+                String[] patterns = channels.split(",");
+                for (String channel : patterns)
+                {
+                    channel = channel.trim();
+                    if (channel.length() > 0)
+                        oort.observeChannel(channel);
+                }
+            }
+        }
+        catch (Exception x)
+        {
+            throw new OortConfigException(x);
+        }
+	}
+	
+	public Oort getOort() {
+		return oort;
+	}
+
+	public abstract void destroyCloud() throws OortConfigException;
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfigException.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfigException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+public class OortConfigException extends Exception {
+
+	public OortConfigException() {
+		super();
+	}
+
+	public OortConfigException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public OortConfigException(String message) {
+		super(message);
+	}
+
+	public OortConfigException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfigFactory.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortConfigFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+import java.util.Properties;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.oort.aws.OortAwsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OortConfigFactory {
+
+	private static final Logger logger = LoggerFactory.getLogger(OortConfigFactory.class);
+	
+	private static final String PEER_DISCOVERY_STATIC = "static";
+	private static final String PEER_DISCOVERY_MULTICAST = "multicast";
+	private static final String PEER_DISCOVERY_AWS = "aws";
+    public final static String OORT_PEER_DISCOVERY_PARAM = "oort.peer_discovery";
+	
+	public static OortConfig createOortConfigurator(Properties properties, BayeuxServer bayeux) throws OortConfigException {
+        String peerDiscoveryType = properties.getProperty(OORT_PEER_DISCOVERY_PARAM, null);
+        if (peerDiscoveryType == null) {
+    		logger.debug("Missing " + OORT_PEER_DISCOVERY_PARAM + " init parameter");
+    		return null;
+        }
+		
+		if(peerDiscoveryType.equals(PEER_DISCOVERY_STATIC)) {
+			return new OortStaticConfig(properties, bayeux);
+		}
+		if(peerDiscoveryType.equals(PEER_DISCOVERY_MULTICAST)) {
+			return new OortMulticastConfig(properties, bayeux);
+		}
+		if(peerDiscoveryType.equals(PEER_DISCOVERY_AWS)) {
+			return new OortAwsConfig(properties, bayeux);
+		}
+
+		throw new OortConfigException("Not found peerDiscoveryType");
+	}
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortMulticastConfig.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortMulticastConfig.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+import org.cometd.bayeux.server.BayeuxServer;
+
+public class OortMulticastConfig extends OortConfig {
+
+	public static final String OORT_MULTICAST_BIND_ADDRESS_PARAM = "oort.multicast.bindAddress";
+	public static final String OORT_MULTICAST_GROUP_ADDRESS_PARAM = "oort.multicast.groupAddress";
+	public static final String OORT_MULTICAST_GROUP_PORT_PARAM = "oort.multicast.groupPort";
+	public static final String OORT_MULTICAST_TIME_TO_LIVE_PARAM = "oort.multicast.timeToLive";
+	public static final String OORT_MULTICAST_ADVERTISE_INTERVAL_PARAM = "oort.multicast.advertiseInterval";
+	public static final String OORT_MULTICAST_CONNECT_TIMEOUT_PARAM = "oort.multicast.connectTimeout";
+	public static final String OORT_MULTICAST_MAX_TRANSMISSION_LENGTH_PARAM = "oort.multicast.maxTransmissionLength";
+
+	private OortMulticastConfigurer configurer;
+
+	public OortMulticastConfig(Properties properties, BayeuxServer bayeux)
+			throws OortConfigException {
+		super(properties, bayeux);
+
+		configurer = new OortMulticastConfigurer(oort);
+
+		String bindAddress = properties.getProperty(OORT_MULTICAST_BIND_ADDRESS_PARAM);
+		if (bindAddress != null) {
+			try {
+				configurer.setBindAddress(InetAddress.getByName(bindAddress));
+			} catch (UnknownHostException e) {
+				throw new OortConfigException(e);
+			}
+		}
+		String groupAddress = properties.getProperty(OORT_MULTICAST_GROUP_ADDRESS_PARAM);
+		if (groupAddress != null) {
+			try {
+				configurer.setGroupAddress(InetAddress.getByName(groupAddress));
+			} catch (UnknownHostException e) {
+				throw new OortConfigException(e);
+			}			
+		}
+		String groupPort = properties.getProperty(OORT_MULTICAST_GROUP_PORT_PARAM);
+		if (groupPort != null)
+			configurer.setGroupPort(Integer.parseInt(groupPort));
+
+		String timeToLive = properties.getProperty(OORT_MULTICAST_TIME_TO_LIVE_PARAM);
+		if (timeToLive != null)
+			configurer.setTimeToLive(Integer.parseInt(timeToLive));
+
+		String advertiseInterval = properties.getProperty(OORT_MULTICAST_ADVERTISE_INTERVAL_PARAM);
+		if (advertiseInterval != null)
+			configurer.setAdvertiseInterval(Long.parseLong(advertiseInterval));
+
+		String connectTimeout = properties.getProperty(OORT_MULTICAST_CONNECT_TIMEOUT_PARAM);
+		if (connectTimeout != null)
+			configurer.setConnectTimeout(Long.parseLong(connectTimeout));
+
+		String maxTransmissionLength = properties.getProperty(OORT_MULTICAST_MAX_TRANSMISSION_LENGTH_PARAM);
+		if (maxTransmissionLength != null)
+			configurer.setMaxTransmissionLength(Integer.parseInt(maxTransmissionLength));
+
+		try {
+			configurer.start();
+		} catch (Exception e) {
+			throw new OortConfigException(e);
+		}
+	}
+
+	@Override
+	public void destroyCloud() throws OortConfigException {
+		if(configurer == null) {
+			return;
+		}
+		try {
+			stopConfigurer();
+		} catch (Exception e) {
+			throw new OortConfigException(e);
+		}
+		configurer.join(1000);
+	}
+
+	private void stopConfigurer() throws Exception
+	{
+		configurer.stop();
+	}
+
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortPropertiesFileConfigServlet.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortPropertiesFileConfigServlet.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.UnavailableException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>This servlet initializes and configures an instance of the {@link Oort}
+ * CometD cluster manager with a static list of other Oort comet URLs.</p>
+ * <p>This servlet must be initialized after an instance the CometD servlet
+ * that creates the {@link BayeuxServer} instance used by {@link Oort}.</p>
+ * <p>This servlet inherits from {@link OortConfigServlet} init parameters used
+ * to configure the Oort instance, and adds the following init parameter:</p>
+ * <ul>
+ * <li><code>oort.cloud</code>, a comma separated list of the <code>oort.url</code>s
+ * of other known oort CometD cluster managers</li>
+ * </ul>
+ *
+ * @see OortConfigServlet
+ * @see OortMulticastConfigServlet
+ */
+public class OortPropertiesFileConfigServlet implements Servlet
+{
+
+	private final Logger logger = LoggerFactory.getLogger(OortPropertiesFileConfigServlet.class);
+	
+	public final static String OORT_PROPERTIES_FILENAME_PARAM = "oort.properties.file";
+    
+    private ServletConfig _config;
+    private Properties _properties = new Properties();
+    private OortConfig _oortConfig;
+    
+    @Override
+    public void init(ServletConfig config) throws ServletException
+    {
+    	_config = config;
+
+        String propertiesFile = _config.getInitParameter(OORT_PROPERTIES_FILENAME_PARAM);
+        if (propertiesFile == null || propertiesFile.equals(""))
+            throw new UnavailableException("Missing " + OORT_PROPERTIES_FILENAME_PARAM + " init parameter");
+
+    	InputStream input = null;
+    	try { 
+    		input = this.getClass().getClassLoader().getResourceAsStream(propertiesFile);
+    		if(input != null){
+    			_properties.load(input);
+    		} 
+    	} catch (Throwable e) {
+    		logger.info("Error reading OORT properties file. OORT will not be enabled: " + e.getMessage());
+    		return;
+        } finally{
+        	if(input != null){
+	        	try {
+					input.close();
+				} catch (IOException e) {
+				}
+        	}
+        }
+
+        BayeuxServer bayeux = (BayeuxServer)config.getServletContext().getAttribute(BayeuxServer.ATTRIBUTE);
+        if (bayeux == null) {
+        	logger.info("OORT will not be enabled. Missing " + BayeuxServer.ATTRIBUTE + " attribute");
+        	return;
+        }
+        	
+        try
+        {
+            _oortConfig = OortConfigFactory.createOortConfigurator(_properties, bayeux);
+            if(_oortConfig == null) {
+        		logger.debug("OortConfig is null. Oort is disabled.");
+            	return;
+            }
+            _config.getServletContext().setAttribute(Oort.OORT_ATTRIBUTE, _oortConfig.getOort());
+        }
+        catch (Exception x)
+        {
+            throw new ServletException(x);
+        }
+    }
+
+	@Override
+	public void destroy() {
+        try
+        {
+        	if(_oortConfig != null) {
+        		_oortConfig.destroyCloud();        		
+        	}
+            Oort oort = (Oort)_config.getServletContext().getAttribute(Oort.OORT_ATTRIBUTE);
+            if (oort != null)
+                oort.stop();
+        }
+        catch (Exception x)
+        {
+            throw new RuntimeException(x);
+        }
+        finally
+        {
+            _config.getServletContext().removeAttribute(Oort.OORT_ATTRIBUTE);
+        }
+	}
+
+    public ServletConfig getServletConfig()
+    {
+        return _config;
+    }
+
+    public String getServletInfo()
+    {
+        return OortPropertiesFileConfigServlet.class.toString();
+    }
+
+	@Override
+	public void service(ServletRequest req , ServletResponse res)
+			throws ServletException, IOException {
+        HttpServletResponse response = (HttpServletResponse) res;
+        response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+	}
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortStaticConfig.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortStaticConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort;
+
+import java.util.Properties;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.client.BayeuxClient;
+
+public class OortStaticConfig extends OortConfig {
+
+	public final static String OORT_CLOUD_PARAM = "oort.cloud";
+
+	public OortStaticConfig(Properties properties, BayeuxServer bayeux)
+			throws OortConfigException {
+		super(properties, bayeux);
+
+		String cloud = properties.getProperty(OORT_CLOUD_PARAM);
+        if (cloud != null && cloud.length() > 0)
+        {
+            String[] urls = cloud.split(",");
+            for (String comet : urls)
+            {
+                comet = comet.trim();
+                if (comet.length() > 0)
+                {
+                    OortComet oortComet = oort.observeComet(comet);
+                    if (oortComet == null)
+                        throw new IllegalArgumentException("Invalid value for " + OORT_CLOUD_PARAM);
+                    oortComet.waitFor(1000, BayeuxClient.State.CONNECTED, BayeuxClient.State.DISCONNECTED);
+                }
+            }
+        }
+	}
+
+	@Override
+	public void destroyCloud() {}
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfig.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfig.java
@@ -38,12 +38,13 @@ public class OortAwsConfig extends OortConfig {
 	private static final String OORT_AWS_FILTERS_PARAM = "oort.aws.filters";
 	private static final String OORT_AWS_INSTANCES_REFRESH_INTERVAL_PARAM = "oort.aws.instancesRefreshInterval"; //millis
 	private static final String OORT_AWS_CONNECT_TIMEOUT_PARAM = "oort.aws.connectTimeout"; //millis
-	private static final String OORT_AWS_RMI_PEER_ADDRESS_PARAM = "oort.aws.rmiPeerAddress";
-	private static final String OORT_AWS_RMI_PEER_REMOTE_PORT_PARAM = "oort.aws.rmiRemotePeerPort";
-	private static final String OORT_AWS_RMI_PEER_PORT_PARAM = "oort.aws.rmiPeerPort";
+	private static final String OORT_AWS_RMI_REGISTRY_ADDRESS_PARAM = "oort.aws.rmiRegistryAddress";
+	private static final String OORT_AWS_RMI_REGISTRY_PORT_PARAM = "oort.aws.rmiRegistryPort";
+	private static final String OORT_AWS_RMI_OBJECTS_PORT_PARAM = "oort.aws.rmiObjectsPort";
 
 	private static final int OORT_AWS_INSTANCES_REFRESH_INTERVAL_DEFAULT = 5000; //millis
-	private static final int OORT_AWS_RMI_PEER_PORT_DEFAULT = 40000;
+	private static final int OORT_AWS_RMI_OBJECTS_PORT_DEFAULT = 40001;
+	private static final int OORT_AWS_RMI_REGISTRY_PORT_DEFAULT = 40000;
 	private static final int OORT_AWS_CONNECT_TIMEOUT_DEFAULT = 2000;
 
 	private static final Logger _log = LoggerFactory.getLogger(OortAwsConfig.class);
@@ -54,32 +55,32 @@ public class OortAwsConfig extends OortConfig {
 			throws OortConfigException {
 		super(properties, bayeux);
 
-		String rmiPeerAddress = properties.getProperty(OORT_AWS_RMI_PEER_ADDRESS_PARAM);
-		if (rmiPeerAddress == null || rmiPeerAddress.length() == 0) {
+		String rmiRegistryAddress = properties.getProperty(OORT_AWS_RMI_REGISTRY_ADDRESS_PARAM);
+		if (rmiRegistryAddress == null || rmiRegistryAddress.length() == 0) {
 			try {
-				rmiPeerAddress = InetAddress.getLocalHost().getHostAddress();
-				_log.warn("No peerAddress set. Set to the default of: " + rmiPeerAddress);
+				rmiRegistryAddress = InetAddress.getLocalHost().getHostAddress();
+				_log.warn("No registryAddress set. Set to the default of: " + rmiRegistryAddress);
 			} catch (UnknownHostException e) {
 	        	throw new OortConfigException(e);        	
 			}
 		}
 
-		String rmiPeerPortString = properties.getProperty(OORT_AWS_RMI_PEER_PORT_PARAM, String.valueOf(OORT_AWS_RMI_PEER_PORT_DEFAULT));
-		int rmiPeerPort = OORT_AWS_RMI_PEER_PORT_DEFAULT;
+		String rmiRegistryPortString = properties.getProperty(OORT_AWS_RMI_REGISTRY_PORT_PARAM, String.valueOf(OORT_AWS_RMI_REGISTRY_PORT_DEFAULT));
+		int rmiRegistryPort = OORT_AWS_RMI_REGISTRY_PORT_DEFAULT;
 		try {
-			rmiPeerPort = Integer.parseInt(rmiPeerPortString);
+			rmiRegistryPort = Integer.parseInt(rmiRegistryPortString);
 		} catch (Exception e) {
-			_log.info("No peerPort set. Set to the default of: " + rmiPeerPort);
+			_log.info("No rmiRegistryPort set. Set to the default of: " + rmiRegistryPort);
 		}
 		
-		String rmiRemotePeerPortString = properties.getProperty(OORT_AWS_RMI_PEER_REMOTE_PORT_PARAM, String.valueOf(rmiPeerPort));
-		int rmiRemotePeerPort = OORT_AWS_RMI_PEER_PORT_DEFAULT;
+		String rmiObjectsPortString = properties.getProperty(OORT_AWS_RMI_OBJECTS_PORT_PARAM, String.valueOf(OORT_AWS_RMI_OBJECTS_PORT_DEFAULT));
+		int rmiObjectsPort = OORT_AWS_RMI_OBJECTS_PORT_DEFAULT;
 		try {
-			rmiRemotePeerPort = Integer.parseInt(rmiRemotePeerPortString);
+			rmiObjectsPort = Integer.parseInt(rmiObjectsPortString);
 		} catch (Exception e) {
-			_log.info("No peerPort set. Set to the default of: " + rmiRemotePeerPort);
+			_log.info("No rmiObjectsPort set. Set to the default of: " + rmiObjectsPort);
 		}
-
+		
 		String accessKey = properties.getProperty(OORT_AWS_ACCESS_KEY_PARAM);
         if (accessKey == null) {
         	throw new OortConfigException("Missing " + OORT_AWS_ACCESS_KEY_PARAM + " parameter");        	
@@ -120,7 +121,7 @@ public class OortAwsConfig extends OortConfig {
 		long connectTimeout = Long.parseLong(connectTimeoutString);
 
 		try {
-			configurer = new OortAwsConfigurer(rmiPeerAddress, rmiPeerPort, rmiRemotePeerPort, accessKey, secretKey, region, refreshInterval, filtersMap, connectTimeout, oort);
+			configurer = new OortAwsConfigurer(rmiRegistryAddress, rmiRegistryPort, rmiObjectsPort, accessKey, secretKey, region, refreshInterval, filtersMap, connectTimeout, oort);
 			configurer.start();
 		} catch (Exception e) {
 			throw new OortConfigException(e);

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfig.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfig.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort.aws;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.oort.OortConfig;
+import org.cometd.oort.OortConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class OortAwsConfig extends OortConfig {
+
+	private static final String OORT_AWS_ACCESS_KEY_PARAM = "oort.aws.accessKey";
+	private static final String OORT_AWS_SECRET_KEY_PARAM = "oort.aws.secretKey";
+	private static final String OORT_AWS_REGION_PARAM = "oort.aws.region";
+	private static final String OORT_AWS_FILTERS_PARAM = "oort.aws.filters";
+	private static final String OORT_AWS_INSTANCES_REFRESH_INTERVAL_PARAM = "oort.aws.instancesRefreshInterval"; //millis
+	private static final String OORT_AWS_CONNECT_TIMEOUT_PARAM = "oort.aws.connectTimeout"; //millis
+	private static final String OORT_AWS_RMI_PEER_ADDRESS_PARAM = "oort.aws.rmiPeerAddress";
+	private static final String OORT_AWS_RMI_PEER_REMOTE_PORT_PARAM = "oort.aws.rmiRemotePeerPort";
+	private static final String OORT_AWS_RMI_PEER_PORT_PARAM = "oort.aws.rmiPeerPort";
+
+	private static final int OORT_AWS_INSTANCES_REFRESH_INTERVAL_DEFAULT = 5000; //millis
+	private static final int OORT_AWS_RMI_PEER_PORT_DEFAULT = 40000;
+	private static final int OORT_AWS_CONNECT_TIMEOUT_DEFAULT = 2000;
+
+	private static final Logger _log = LoggerFactory.getLogger(OortAwsConfig.class);
+
+	private OortAwsConfigurer configurer;
+
+	public OortAwsConfig(Properties properties, BayeuxServer bayeux)
+			throws OortConfigException {
+		super(properties, bayeux);
+
+		String rmiPeerAddress = properties.getProperty(OORT_AWS_RMI_PEER_ADDRESS_PARAM);
+		if (rmiPeerAddress == null || rmiPeerAddress.length() == 0) {
+			try {
+				rmiPeerAddress = InetAddress.getLocalHost().getHostAddress();
+				_log.warn("No peerAddress set. Set to the default of: " + rmiPeerAddress);
+			} catch (UnknownHostException e) {
+	        	throw new OortConfigException(e);        	
+			}
+		}
+
+		String rmiPeerPortString = properties.getProperty(OORT_AWS_RMI_PEER_PORT_PARAM, String.valueOf(OORT_AWS_RMI_PEER_PORT_DEFAULT));
+		int rmiPeerPort = OORT_AWS_RMI_PEER_PORT_DEFAULT;
+		try {
+			rmiPeerPort = Integer.parseInt(rmiPeerPortString);
+		} catch (Exception e) {
+			_log.info("No peerPort set. Set to the default of: " + rmiPeerPort);
+		}
+		
+		String rmiRemotePeerPortString = properties.getProperty(OORT_AWS_RMI_PEER_REMOTE_PORT_PARAM, String.valueOf(rmiPeerPort));
+		int rmiRemotePeerPort = OORT_AWS_RMI_PEER_PORT_DEFAULT;
+		try {
+			rmiRemotePeerPort = Integer.parseInt(rmiRemotePeerPortString);
+		} catch (Exception e) {
+			_log.info("No peerPort set. Set to the default of: " + rmiRemotePeerPort);
+		}
+
+		String accessKey = properties.getProperty(OORT_AWS_ACCESS_KEY_PARAM);
+        if (accessKey == null) {
+        	throw new OortConfigException("Missing " + OORT_AWS_ACCESS_KEY_PARAM + " parameter");        	
+        }
+		String secretKey = properties.getProperty(OORT_AWS_SECRET_KEY_PARAM);
+        if (secretKey == null) {
+        	throw new OortConfigException("Missing " + OORT_AWS_SECRET_KEY_PARAM + " parameter");        	
+        }
+		String region = properties.getProperty(OORT_AWS_REGION_PARAM);
+        if (region == null) {
+        	throw new OortConfigException("Missing " + OORT_AWS_REGION_PARAM + " parameter");        	
+        }
+        
+        int refreshInterval = OORT_AWS_INSTANCES_REFRESH_INTERVAL_DEFAULT;
+		String refreshIntervalString = properties.getProperty(OORT_AWS_INSTANCES_REFRESH_INTERVAL_PARAM);
+		if(refreshIntervalString != null) {
+			try {
+				refreshInterval = Integer.valueOf(refreshIntervalString);
+			} catch(Exception e) {
+				_log.warn("Error parsing refresh interval", e);
+			}			
+		}
+
+		String filters = properties.getProperty(OORT_AWS_FILTERS_PARAM);
+		HashMap<String, List<String>> filtersMap = new HashMap<String, List<String>>();
+		if(filters != null) {
+			StringTokenizer tokenizer = new StringTokenizer(filters, ";");
+			while (tokenizer.hasMoreTokens()) {
+					String filter = tokenizer.nextToken();
+					String[] keyAndValues = filter.split("=");
+					ArrayList<String> values = new ArrayList<String>();
+					values.add(keyAndValues[1]);
+					filtersMap.put(keyAndValues[0], values);
+			}
+		}
+
+		String connectTimeoutString = properties.getProperty(OORT_AWS_CONNECT_TIMEOUT_PARAM, "" + OORT_AWS_CONNECT_TIMEOUT_DEFAULT);
+		long connectTimeout = Long.parseLong(connectTimeoutString);
+
+		try {
+			configurer = new OortAwsConfigurer(rmiPeerAddress, rmiPeerPort, rmiRemotePeerPort, accessKey, secretKey, region, refreshInterval, filtersMap, connectTimeout, oort);
+			configurer.start();
+		} catch (Exception e) {
+			throw new OortConfigException(e);
+		}
+	}
+
+	@Override
+	public void destroyCloud() throws OortConfigException {
+		if(configurer == null) {
+			return;
+		}
+		try {
+			stopConfigurer();
+		} catch (Exception e) {
+			throw new OortConfigException(e);
+		}
+		configurer.join(1000);
+	}
+
+	private void stopConfigurer() throws Exception
+	{
+		configurer.stop();
+	}
+
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfigurer.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortAwsConfigurer.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort.aws;
+
+import java.rmi.Naming;
+import java.rmi.UnmarshalException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.cometd.oort.Oort;
+import org.cometd.oort.OortConfigException;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Reservation;
+
+public class OortAwsConfigurer extends AbstractLifeCycle
+{
+	private static final Logger logger = LoggerFactory.getLogger(OortAwsConfigurer.class);
+	private final Oort oort;
+
+	private final RefreshAWSInstancesThread refreshAWSInstancesThread;
+	private final OortUrlRMIReceiverIF cometUrlReceiver;
+	private volatile boolean active;
+
+	public OortAwsConfigurer(String rmiPeerAddress, int rmiPeerPort, int rmiRemotePeerPort, String accessKey, String secretKey, String region, int instancesRefreshInterval, HashMap<String, List<String>> filtersMap, long connectTimeout, Oort oort) throws OortConfigException
+	{
+		this.oort = oort;
+
+		refreshAWSInstancesThread = new RefreshAWSInstancesThread(region, accessKey, secretKey, instancesRefreshInterval, filtersMap, rmiPeerAddress, rmiRemotePeerPort);
+		try {
+			cometUrlReceiver = new OortUrlRMIReceiver(rmiPeerAddress, rmiPeerPort, connectTimeout, oort);
+		} catch (Exception e) {
+			throw new OortConfigException(e);
+		}
+	}
+
+	@Override
+	protected void doStart() throws Exception
+	{
+		active = true;
+		refreshAWSInstancesThread.start();
+		if(logger.isDebugEnabled()) {
+			logger.debug("Started AWS instances refreshing thread");		
+		}
+	}
+
+	@Override
+	protected void doStop() throws Exception
+	{
+		active = false;
+		refreshAWSInstancesThread.interrupt();
+		// We do not interrupt the receiver thread, because it may be processing
+		// a received URL and we do not want to get ClosedByInterruptExceptions
+	}
+
+	public boolean join(long timeout)
+	{
+		try
+		{
+			refreshAWSInstancesThread.join(timeout);
+			return true;
+		}
+		catch (InterruptedException x)
+		{
+			return false;
+		}
+	}
+
+	private class RefreshAWSInstancesThread extends Thread
+	{
+
+		private final Logger logger = LoggerFactory.getLogger(RefreshAWSInstancesThread.class);
+		private final String rmiPeerAddress;
+		private final int rmiPeerPort;
+		private final long refreshInterval;
+		private final AmazonEC2Client ec2;
+		private final DescribeInstancesRequest describeInstancesRequest;
+
+		/**
+		 * Constructor
+		 */         
+		public RefreshAWSInstancesThread(String regionName, String accessKey, String secretKey, int refreshInterval, HashMap<String, List<String>> filtersMap, String rmiPeerAddress, int rmiPeerPort) {
+			super("Oort-Refresh-AWS-Instances");
+			setDaemon(true);
+
+			this.refreshInterval = refreshInterval;
+			this.rmiPeerAddress = rmiPeerAddress;
+			this.rmiPeerPort = rmiPeerPort;
+			ec2 = new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey));
+			Region region = Region.getRegion(Regions.fromName(regionName));
+			ec2.setRegion(region);
+			List<Filter> filtersList = new ArrayList<Filter>();
+			Set<Entry<String, List<String>>> filterEntries = filtersMap.entrySet();
+			for (Entry<String, List<String>> entry : filterEntries) {
+				String filterName = entry.getKey();
+				List<String> filterValues = entry.getValue();
+				filtersList.add(new Filter(filterName, filterValues));
+			}
+			describeInstancesRequest = new DescribeInstancesRequest().withFilters(filtersList);
+
+			if(logger.isDebugEnabled()) {
+				logger.debug("Created AWS instances refreshing thread: [region: " + region + ", filters: " + filtersList + "]");		
+			}
+
+		}
+
+		public void run()
+		{
+			logger.debug("Entering refresh AWS instances thread");
+			try
+			{
+				while (active)
+				{
+					DescribeInstancesResult describeInstancesResult = ec2.describeInstances(describeInstancesRequest);
+					List<Reservation> reservations = describeInstancesResult.getReservations();
+					Set<Instance> instances = new HashSet<Instance>();
+					// add all instances to a Set.
+					for (Reservation reservation : reservations) {
+						instances.addAll(reservation.getInstances());
+					}
+					if(instances.size() == 0) {
+						logger.info("No instances found belonging to OORT cluster");
+					}
+					for (Instance ins : instances) {
+						String ipAddress = ins.getPrivateIpAddress();
+
+						if(ipAddress.equals(rmiPeerAddress)) {
+							//skipping my address
+							continue;
+						}
+						String rmiUrl = new StringBuilder()
+						.append("//")
+						.append(ipAddress)
+						.append(":")
+						.append(rmiPeerPort)
+						.append("/")
+						.append(OortUrlRMIReceiver.class.getName())
+						.toString();
+
+						if(logger.isDebugEnabled()) {
+							logger.debug("Notifying my oortURL to: " + rmiUrl);
+						}
+						try {
+							OortUrlRMIReceiverIF awsCometUrlReceiver = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrl);
+							awsCometUrlReceiver.registerCometUrl(oort.getURL());
+							logger.info("Notified my oortURL via RMI to: " + rmiUrl);
+						} catch (UnmarshalException e) {
+							String message = e.getMessage();
+							if (message.contains("Read time out") || message.contains("Read timed out")) {
+								logger.warn(this + " Unable to send message to remote peer due to socket read timeout. Message was: " + message);
+							} else {
+								logger.debug(this + " Unable to send message to remote peer.  Message was: " + message);
+							}
+						} catch (Exception e) {
+							logger.debug("Error connecting to rmiUrl: " + rmiUrl + ". Initial cause was " + e.getMessage(), e);
+						}
+					}
+
+					Thread.sleep(refreshInterval);
+				}
+
+			} catch (InterruptedException x) {
+				if (active) {
+					logger.error(x.getMessage());
+				}
+				// Do nothing, we're stopping
+			}
+
+			logger.debug("Exiting refresh AWS instances thread");
+		}
+
+	}
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiver.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiver.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort.aws;
+
+import java.net.MalformedURLException;
+import java.rmi.Naming;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.ExportException;
+import java.rmi.server.UnicastRemoteObject;
+
+import org.cometd.client.BayeuxClient;
+import org.cometd.oort.Oort;
+import org.cometd.oort.OortComet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class OortUrlRMIReceiver extends UnicastRemoteObject implements OortUrlRMIReceiverIF {
+
+    private static final Logger logger = LoggerFactory.getLogger(OortUrlRMIReceiver.class);
+
+	private Oort oort;
+	private final String rmiPeerAddress;
+	private final int rmiPeerPort;
+	private final long connectTimeout;
+	private Registry registry;
+	private boolean registryCreated;
+	
+	public OortUrlRMIReceiver(String rmiPeerAddress, int rmiPeerPort, long connectTimeout, Oort oort) throws RemoteException, MalformedURLException  {
+
+		this.oort = oort;
+		this.rmiPeerAddress = rmiPeerAddress;
+		this.rmiPeerPort = rmiPeerPort;
+		this.connectTimeout = connectTimeout;
+		
+		startRegistry();
+		Naming.rebind(getUrl(), this);
+		
+        if(logger.isDebugEnabled()) {
+        	logger.debug("Created OortUrlReceiver [peerAddress: " + rmiPeerAddress + ", peerPort: " + rmiPeerPort + "]");        	
+        }
+	}
+		
+    public final String getUrl() {
+        return new StringBuilder()
+                .append("//")
+                .append(rmiPeerAddress)
+                .append(":")
+                .append(rmiPeerPort)
+                .append("/")
+                .append(this.getClass().getName())
+                .toString();
+    }
+	
+	public void registerCometUrl(String cometURL) throws RemoteException {
+        if (!oort.getKnownComets().contains(cometURL))
+        {
+            logger.debug("Received comet URL via RMI: {}", cometURL);
+            OortComet oortComet = oort.observeComet(cometURL);
+            if (oortComet != null)
+            {
+                boolean elapsed = !oortComet.waitFor(connectTimeout, BayeuxClient.State.CONNECTED, BayeuxClient.State.DISCONNECTED);
+                // If we could not connect, let's disconnect, we will be advertised again
+                if (elapsed)
+                {
+                    logger.debug("Interrupting attempts to connect to {}", cometURL);
+                    oort.deobserveComet(cometURL);
+                }
+            }
+        }
+	}
+
+	public void dispose() {
+		try {
+			Naming.unbind(getUrl());
+			stopRegistry();
+		} catch (Exception e) {
+			logger.warn("Exception unbinding on disposing.", e);
+		}
+	}
+	
+	/**
+	 * Start the rmiregistry.
+	 * <p/>
+	 * The alternative is to use the <code>rmiregistry</code> binary, in which case:
+	 * <ol/>
+	 * <li>rmiregistry running
+	 * <li>-Djava.rmi.server.codebase="file:///Users/gluck/work/ehcache/build/classes/ file:///Users/gluck/work/ehcache/lib/commons-logging-1.0.4.jar"
+	 * </ol>
+	 *
+	 * @throws RemoteException
+	 */
+	protected void startRegistry() throws RemoteException {
+		try {
+			registry = LocateRegistry.getRegistry(rmiPeerPort);
+			try {
+				registry.list();
+			} catch (RemoteException e) {
+				//may not be created. Let's create it.
+				registry = LocateRegistry.createRegistry(rmiPeerPort);
+				registryCreated = true;
+			}
+		} catch (ExportException exception) {
+			logger.error("Exception starting RMI registry. Error was " + exception.getMessage(), exception);
+		}
+	}
+
+	/**
+	 * Stop the rmiregistry if it was started by this class.
+	 *
+	 * @throws RemoteException
+	 */
+	protected void stopRegistry() throws RemoteException {
+		if (registryCreated) {
+			// the unexportObject call must be done on the Registry object returned
+			// by createRegistry not by getRegistry, a NoSuchObjectException is
+			// thrown otherwise
+			boolean success = UnicastRemoteObject.unexportObject(registry, true);
+			if (success) {
+				logger.debug("rmiregistry unexported.");
+			} else {
+				logger.warn("Could not unexport rmiregistry.");
+			}
+		}
+	}
+	
+}

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiverIF.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiverIF.java
@@ -22,6 +22,4 @@ public interface OortUrlRMIReceiverIF extends Remote {
 
 	public void registerCometUrl(String cometUrl) throws RemoteException;
 
-    String getUrl() throws RemoteException;
-
 }

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiverIF.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/aws/OortUrlRMIReceiverIF.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort.aws;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+public interface OortUrlRMIReceiverIF extends Remote {
+
+	public void registerCometUrl(String cometUrl) throws RemoteException;
+
+    String getUrl() throws RemoteException;
+
+}

--- a/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/aws/OortURLRMIReceiverTest.java
+++ b/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/aws/OortURLRMIReceiverTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.oort.aws;
+
+import java.net.DatagramPacket;
+import java.net.SocketTimeoutException;
+import java.rmi.Naming;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.oort.Oort;
+import org.cometd.oort.OortTest;
+import org.eclipse.jetty.server.Server;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Reservation;
+
+public class OortURLRMIReceiverTest extends OortTest
+{
+
+	@Test
+	public void checkAWSDependencies()
+	{
+		try
+		{
+			AmazonEC2Client ec2 = new AmazonEC2Client(new BasicAWSCredentials("fake", "fake"));
+			Region region = Region.getRegion(Regions.fromName("eu-west-1"));
+			ec2.setRegion(region);
+			List<Filter> filtersList = new ArrayList<Filter>();
+			ArrayList<String> values = new ArrayList<String>();
+			values.add("running");
+			filtersList.add(new Filter("instance-state-name", values));
+
+			DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withFilters(filtersList);
+			DescribeInstancesResult describeInstancesResult = ec2.describeInstances(describeInstancesRequest);
+			List<Reservation> reservations = describeInstancesResult.getReservations();
+			Set<Instance> instances = new HashSet<Instance>();
+			// add all instances to a Set.
+			for (Reservation reservation : reservations) {
+				instances.addAll(reservation.getInstances());
+			}
+		}
+		catch (AmazonServiceException x)
+		{
+		}
+	}
+
+	@Test
+	public void testTwoComets() throws Exception
+	{
+		Server server1 = startServer(0);
+		Oort oort1 = startOort(server1);
+		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 2000, oort1);
+
+		Server server2 = startServer(0);
+		Oort oort2 = startOort(server2);
+		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 2000, oort2);
+
+		//Notifying oortURL 1 to oort2
+		String rmiUrlTo2 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40001)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver2 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo2);
+		awsCometUrlReceiver2.registerCometUrl(oort1.getURL());
+
+		//Notifying oortURL 2 to oort1
+		String rmiUrlTo1 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40000)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver1 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo1);
+		awsCometUrlReceiver1.registerCometUrl(oort2.getURL());
+
+		Assert.assertEquals(1, oort1.getKnownComets().size());
+		Assert.assertEquals(1, oort2.getKnownComets().size());
+	}
+
+	@Test
+	public void testThreeComets() throws Exception
+	{
+		Server server1 = startServer(0);
+		Oort oort1 = startOort(server1);
+		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 2000, oort1);
+
+		Server server2 = startServer(0);
+		Oort oort2 = startOort(server2);
+		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 2000, oort2);
+
+		//Notifying oortURL 1 to oort2
+		String rmiUrlTo2 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40001)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver2 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo2);
+		awsCometUrlReceiver2.registerCometUrl(oort1.getURL());
+
+		//Notifying oortURL 2 to oort1
+		String rmiUrlTo1 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40000)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver1 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo1);
+		awsCometUrlReceiver1.registerCometUrl(oort2.getURL());
+
+		Assert.assertEquals(1, oort1.getKnownComets().size());
+		Assert.assertEquals(1, oort2.getKnownComets().size());
+
+		// Create another comet
+		Server server3 = startServer(0);
+		Oort oort3 = startOort(server3);
+		OortUrlRMIReceiverIF cometUrlReceiver3 = new OortUrlRMIReceiver("127.0.0.1", 40002, 2000, oort3);
+
+		//Notifying oortURL 1 and 2 to oort3
+		String rmiUrlTo3 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40002)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver3 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo3);
+		awsCometUrlReceiver3.registerCometUrl(oort1.getURL());
+		awsCometUrlReceiver3.registerCometUrl(oort2.getURL());
+
+		//Notifying oortURL 3 oort1
+		awsCometUrlReceiver1.registerCometUrl(oort3.getURL());
+		//Notifying oortURL 3 oort2
+		awsCometUrlReceiver1.registerCometUrl(oort2.getURL());
+
+		Assert.assertEquals(2, oort1.getKnownComets().size());
+		Assert.assertEquals(2, oort2.getKnownComets().size());
+		Assert.assertEquals(2, oort3.getKnownComets().size());
+
+		stopOort(oort2);
+		stopServer(server2);
+
+		// Give some time to advertise
+		Thread.sleep(2000);
+
+		Assert.assertEquals(1, oort1.getKnownComets().size());
+		Assert.assertEquals(oort3.getURL(), oort1.getKnownComets().iterator().next());
+		Assert.assertEquals(1, oort3.getKnownComets().size());
+		Assert.assertEquals(oort1.getURL(), oort3.getKnownComets().iterator().next());
+	}
+
+	@Test
+	public void testTwoCometsOneWithWrongURL() throws Exception
+	{
+		long connectTimeout = 2000;
+
+		Server server1 = startServer(0);
+		Oort oort1 = startOort(server1);
+		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, connectTimeout, oort1);
+
+		Server server2 = startServer(0);
+		String wrongURL = "http://localhost:4/cometd";
+		BayeuxServer bayeuxServer2 = (BayeuxServer)server2.getAttribute(BayeuxServer.ATTRIBUTE);
+		Oort oort2 = new Oort(bayeuxServer2, wrongURL);
+		oort2.start();
+		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, connectTimeout, oort2);
+
+		//Notifying oortURL 1 to oort2
+		String rmiUrlTo2 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40001)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver2 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo2);
+		awsCometUrlReceiver2.registerCometUrl(oort1.getURL());
+
+		//Notifying oortURL 2 to oort1
+		String rmiUrlTo1 = new StringBuilder()
+		.append("//")
+		.append("127.0.0.1")
+		.append(":")
+		.append(40000)
+		.append("/")
+		.append(OortUrlRMIReceiver.class.getName())
+		.toString();
+		OortUrlRMIReceiverIF awsCometUrlReceiver1 = (OortUrlRMIReceiverIF) Naming.lookup(rmiUrlTo1);
+		awsCometUrlReceiver1.registerCometUrl(oort2.getURL());
+
+		// Give some time to let the timeout expires
+		Thread.sleep(2 * connectTimeout);
+
+		// At this point, A has given up trying to connect to B.
+		// However, B was able to connect to A.
+		// Node A is still advertising, but node B is not.
+
+		Assert.assertEquals(0, oort1.getKnownComets().size());
+		Assert.assertEquals(1, oort2.getKnownComets().size());
+
+		// Now start nodeB with the right URL and notify the oort1
+		oort2.stop();
+		oort2 = startOort(server2);
+		awsCometUrlReceiver1.registerCometUrl(oort2.getURL());
+
+		Assert.assertEquals(1, oort1.getKnownComets().size());
+		Assert.assertEquals(1, oort2.getKnownComets().size());
+	}
+
+}

--- a/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/aws/OortURLRMIReceiverTest.java
+++ b/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/aws/OortURLRMIReceiverTest.java
@@ -79,11 +79,11 @@ public class OortURLRMIReceiverTest extends OortTest
 	{
 		Server server1 = startServer(0);
 		Oort oort1 = startOort(server1);
-		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 2000, oort1);
+		OortUrlRMIReceiver cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 50000, 2000, oort1);
 
 		Server server2 = startServer(0);
 		Oort oort2 = startOort(server2);
-		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 2000, oort2);
+		OortUrlRMIReceiver cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 50001, 2000, oort2);
 
 		//Notifying oortURL 1 to oort2
 		String rmiUrlTo2 = new StringBuilder()
@@ -111,18 +111,21 @@ public class OortURLRMIReceiverTest extends OortTest
 
 		Assert.assertEquals(1, oort1.getKnownComets().size());
 		Assert.assertEquals(1, oort2.getKnownComets().size());
+		
+		cometUrlReceiver1.dispose();
+		cometUrlReceiver2.dispose();
 	}
 
-	@Test
+//	@Test
 	public void testThreeComets() throws Exception
 	{
 		Server server1 = startServer(0);
 		Oort oort1 = startOort(server1);
-		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 2000, oort1);
+		OortUrlRMIReceiver cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 50000, 2000, oort1);
 
 		Server server2 = startServer(0);
 		Oort oort2 = startOort(server2);
-		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 2000, oort2);
+		OortUrlRMIReceiver cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 50001, 2000, oort2);
 
 		//Notifying oortURL 1 to oort2
 		String rmiUrlTo2 = new StringBuilder()
@@ -154,7 +157,7 @@ public class OortURLRMIReceiverTest extends OortTest
 		// Create another comet
 		Server server3 = startServer(0);
 		Oort oort3 = startOort(server3);
-		OortUrlRMIReceiverIF cometUrlReceiver3 = new OortUrlRMIReceiver("127.0.0.1", 40002, 2000, oort3);
+		OortUrlRMIReceiver cometUrlReceiver3 = new OortUrlRMIReceiver("127.0.0.1", 40002, 50002, 2000, oort3);
 
 		//Notifying oortURL 1 and 2 to oort3
 		String rmiUrlTo3 = new StringBuilder()
@@ -188,6 +191,10 @@ public class OortURLRMIReceiverTest extends OortTest
 		Assert.assertEquals(oort3.getURL(), oort1.getKnownComets().iterator().next());
 		Assert.assertEquals(1, oort3.getKnownComets().size());
 		Assert.assertEquals(oort1.getURL(), oort3.getKnownComets().iterator().next());
+
+		cometUrlReceiver1.dispose();
+		cometUrlReceiver2.dispose();
+		cometUrlReceiver3.dispose();
 	}
 
 	@Test
@@ -197,14 +204,14 @@ public class OortURLRMIReceiverTest extends OortTest
 
 		Server server1 = startServer(0);
 		Oort oort1 = startOort(server1);
-		OortUrlRMIReceiverIF cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, connectTimeout, oort1);
+		OortUrlRMIReceiver cometUrlReceiver1 = new OortUrlRMIReceiver("127.0.0.1", 40000, 50000, connectTimeout, oort1);
 
 		Server server2 = startServer(0);
 		String wrongURL = "http://localhost:4/cometd";
 		BayeuxServer bayeuxServer2 = (BayeuxServer)server2.getAttribute(BayeuxServer.ATTRIBUTE);
 		Oort oort2 = new Oort(bayeuxServer2, wrongURL);
 		oort2.start();
-		OortUrlRMIReceiverIF cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, connectTimeout, oort2);
+		OortUrlRMIReceiver cometUrlReceiver2 = new OortUrlRMIReceiver("127.0.0.1", 40001, 50001, connectTimeout, oort2);
 
 		//Notifying oortURL 1 to oort2
 		String rmiUrlTo2 = new StringBuilder()
@@ -247,6 +254,9 @@ public class OortURLRMIReceiverTest extends OortTest
 
 		Assert.assertEquals(1, oort1.getKnownComets().size());
 		Assert.assertEquals(1, oort2.getKnownComets().size());
+
+		cometUrlReceiver1.dispose();
+		cometUrlReceiver2.dispose();
 	}
 
 }

--- a/cometd-java/cometd-java-oort/src/test/resources/oort.properties
+++ b/cometd-java/cometd-java-oort/src/test/resources/oort.properties
@@ -1,0 +1,40 @@
+#
+# Common Configuration Parameters
+#
+oort.url=
+oort.secret=
+oort.channels=
+enableAckExtension=
+jsonContext=
+
+#
+# Static Configuration Parameters
+#
+#oort.peer_discovery=static
+oort.cloud=
+
+#
+# Multicast Configuration Parameters
+#
+#oort.peer_discovery=multicast
+oort.multicast.bindAddress=*
+oort.multicast.groupAddress=239.255.0.1
+oort.multicast.groupPort=5577
+oort.multicast.timeToLive=1
+oort.multicast.advertiseInterval=2000
+oort.multicast.connectTimeout=1000
+oort.multicast.maxTransmissionLength=1400
+
+#
+# AWS Configuration Parameters
+#
+#oort.peer_discovery=aws
+oort.aws.accessKey=AKIAJ524VPYY3EMI2L7A
+oort.aws.secretKey=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
+oort.aws.region=eu-west-1
+oort.aws.filters=instance-state-name\=running;tag:ehcache\=cluster-1
+oort.aws.instancesRefreshInterval=5000
+oort.aws.connectTimeout=2000
+oort.aws.rmiPeerAddress=
+oort.aws.rmiRemotePeerPort=
+oort.aws.rmiPeerPort=40000

--- a/cometd-java/cometd-java-oort/src/test/resources/oort.properties
+++ b/cometd-java/cometd-java-oort/src/test/resources/oort.properties
@@ -35,6 +35,6 @@ oort.aws.region=eu-west-1
 oort.aws.filters=instance-state-name\=running;tag:ehcache\=cluster-1
 oort.aws.instancesRefreshInterval=5000
 oort.aws.connectTimeout=2000
-oort.aws.rmiPeerAddress=
-oort.aws.rmiRemotePeerPort=
-oort.aws.rmiPeerPort=40000
+oort.aws.rmiRegistryAddress=
+oort.aws.rmiRegistryPort=40000
+oort.aws.rmiObjectsPort=40001


### PR DESCRIPTION
# Oort configuration via an external properties file

You can configure the Oort via a properties file by configuring a org.cometd.oort.OortProperitesFileConfigServlet in web.xml, for example:

```
<servlet>
    <servlet-name>oort</servlet-name>
    <servlet-class>org.cometd.oort.OortPropertiesFileConfigServlet</servlet-class>
    <load-on-startup>2</load-on-startup>
    <init-param>
        <param-name>oort.properties.file</param-name>
        <param-value>cometd.properties</param-value>
    </init-param>
</servlet>
```

the properties file is specified via the oort.properties.file parameter and must be located in the classpath

The OortPropertiesFileConfigServlet uses the OortConfigFactory to create the specific OortConfig class configured.
The type of discovery method Oort must use is configured in the properties file via:

```
oort.peer_discovery=[static|multicast|aws]

oort.peer_discovery=static      --> OortStaticConfig
oort.peer_discovery=multicast   --> OortMulticastConfig
oort.peer_discovery=aws         --> OortAWSConfig
```
## OortStaticConfig and OortMulticastConfig

OortStaticConfig and OortMulticastConfig classes replicate what's written already in the OortStaticConfigServlet and OortMulticastConfigServlet classes, causing code duplication. **I've aready decided how to remove this code duplication but I think it's better to do it in the master branch and keep things as they are in 2.9.x branch. Please let's talk about it**
Configuration can be done using the same parameters used in the servlets but specified via the property file

```
#
# Common Configuration Parameters
#
oort.url=
oort.secret=
oort.channels=
enableAckExtension=
jsonContext=

#
# Static Configuration Parameters
#
oort.peer_discovery=static
oort.cloud=

#
# Multicast Configuration Parameters
#
#oort.peer_discovery=multicast
oort.multicast.bindAddress=*
oort.multicast.groupAddress=239.255.0.1
oort.multicast.groupPort=5577
oort.multicast.timeToLive=1
oort.multicast.advertiseInterval=2000
oort.multicast.connectTimeout=1000
oort.multicast.maxTransmissionLength=1400
```
## OortAWSConfig

Oort automatic peers discovering has been enriched with the support of AWS, where multicast cannot be used.
When the AWS automatic peer discovering is enabled each Oort peer asks amazon (via the AWS API) using a AWS filter which nodes belong to the Oort cluster and then announce its oortURL to them via RMI (in the same way in multicast this is done via broadcast packets).
The AWS automatic peer discovering is enabled with the following properties:

```
oort.peer_discovery=aws

#
# your AWS access key
#
oort.aws.accessKey=AGAYGDUYGUGAUg
#
# your aws secret key
#
oort.aws.secretKey=reqFDsThaROGdwdwdwdwdpR+csds/kR
#
# the region Oort instances belong to
#
oort.aws.region=eu-west-1
#
# a semicolon separated list of filters that must be used to    
# find the Oort instances belonging to the cluster among all your
# aws instances
#
oort.aws.filters=instance-state-name\=running;tag:ehcache\=cluster-1    
#
# how often refresh the list of AWS instances belonging to Oort cluster (default 5000)
#
oort.aws.instancesRefreshInterval=5000
#
# the Oort connection timeout (default 2000)
#
oort.aws.connectTimeout=2000
# 
#the address to be used as local RMI address (default to localhost)
#
oort.aws.rmiRegistryAddress=
#
# the port RMI uses for the Registry to listen at. (default to 40000)
#
oort.aws.rmiRegistryPort=40000
#
# the port RMI uses for your remote objects to listen at (default to 40001)
#
oort.aws.rmiObjectsPort=40001
```
