### PR TITLE
Do not reject connection messages in the same HTTP request as others.

### DIFF
--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -18,6 +18,7 @@ package org.cometd.server;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.Arrays;
 
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerTransport;
@@ -147,15 +148,21 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
 
     protected ServerMessage.Mutable[] parseMessages(BufferedReader reader, boolean jsonDebug) throws ParseException, IOException
     {
-        if (jsonDebug)
+        if (jsonDebug) {
             return parseMessages(IO.toString(reader));
-        else
-            return jsonContext.parse(reader);
+        } else {
+            return sorted(jsonContext.parse(reader));
+        }
     }
 
     protected ServerMessage.Mutable[] parseMessages(String json) throws ParseException
     {
-        return jsonContext.parse(json);
+        return sorted(jsonContext.parse(json));
+    }
+
+    private static ServerMessage.Mutable[] sorted(ServerMessage.Mutable[] messages) {
+        Arrays.sort(messages, MessageOrdering.COMPARATOR);
+        return messages;
     }
 
     /**

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/MessageOrdering.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/MessageOrdering.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.server;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.cometd.bayeux.Channel;
+import org.cometd.bayeux.server.ServerMessage;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+public class MessageOrdering implements Comparator<ServerMessage.Mutable> {
+    public static final Comparator<ServerMessage.Mutable> COMPARATOR = new MessageOrdering();
+
+    private static final List<String> CHANNEL_ORDERING = unmodifiableList(asList(Channel.META_HANDSHAKE, Channel.META_CONNECT));
+    private static final int AFTER_ALL_RELEVANT_MESSAGES = CHANNEL_ORDERING.size();
+
+    private MessageOrdering() { }
+
+    @Override
+    public int compare(ServerMessage.Mutable messageA, ServerMessage.Mutable messageB) {
+        return Integer.compare(relativePositionOf(messageA), relativePositionOf(messageB));
+    }
+
+    private static int relativePositionOf(ServerMessage.Mutable message) {
+        int index = CHANNEL_ORDERING.indexOf(message.getChannel());
+        if (index >= 0) {
+            return index;
+        }
+        return AFTER_ALL_RELEVANT_MESSAGES;
+    }
+}

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractHttpTransport.java
@@ -184,8 +184,6 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport
                     }
                     case Channel.META_CONNECT:
                     {
-                        if (messages.length > 1)
-                            throw new IOException();
                         ServerMessage.Mutable reply = processMetaConnect(request, response, session, message);
                         messages[i] = processReply(session, reply);
                         startInterval = sendQueue = sendReplies = reply != null;


### PR DESCRIPTION
From the Bayeux specification:

> "A client MAY send other messages in the same HTTP request with a connection message. A server MUST handle any other message sent in the same request as a connect message after the handling of the connect message is complete."

This implies that connection messages that are sent alongside other messages should not be met with an `IOException`, but instead handled first. This is the behaviour expected by the Faye client. In this commit, this is done by sorting the messages such that the connection messages come first.

We also sort the messages such that any handshake message are seen immediately, so that we can fail quickly.

---

This pull request is intended as a proof of concept, and shouldn't be merged as-is. The code is tested manually only, and I'd like to get some automated tests in place, but I don't know where, so advice would be appreciated. I'd also like to know if I'm violating the expected style of the code in any way. I could also just be missing something fundamental. I'm not too familiar with the code, so the main point of this PR is just to get some eyes on the code so someone with more knowledge can identify what's missing.
