### PR TITLE
[COMETD-557] asyncContext not needed here.  fixes:

### DIFF
--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
@@ -15,20 +15,20 @@
  */
 package org.cometd.server.transport;
 
-import org.cometd.bayeux.server.ServerMessage;
-import org.cometd.server.BayeuxServerImpl;
-import org.cometd.server.ServerSessionImpl;
-
-import javax.servlet.AsyncContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cometd.bayeux.server.ServerMessage;
+import org.cometd.server.BayeuxServerImpl;
+import org.cometd.server.ServerSessionImpl;
 
 /**
  * <p>The base class for HTTP transports that use blocking stream I/O.</p>


### PR DESCRIPTION
See previous pull here, which had other non-related commits: https://github.com/cometd/cometd/pull/23

JSONP transport throwing exception "Async not started"
ex:
Undertow.io:  2014-10-07 16:51:11,211 ERROR[io.undertow.request] UT005023: Exception handling request to /comet: java.lang.IllegalStateException: UT010018: Async not started
     at io.undertow.servlet.spec.HttpServletRequestImpl.getAsyncContext(HttpServletRequestImpl.java:972)
(cherry picked from commit ac38fd9)
