### PR TITLE
COMETD-565 - encode output stream using Response character encoding 

### DIFF
--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
@@ -132,7 +132,7 @@ public abstract class AbstractStreamHttpTransport extends AbstractHttpTransport
                     ServerMessage message = messages.get(i);
                     if (i > 0)
                         output.print(",");
-                    writeMessage(output, session, message);
+                    writeMessage(response, session, message);
                 }
             }
             finally
@@ -154,10 +154,10 @@ public abstract class AbstractStreamHttpTransport extends AbstractHttpTransport
                 if (needsComma)
                     output.print(",");
                 needsComma = true;
-                writeMessage(output, session, reply);
+                writeMessage(response, session, reply);
             }
 
-            endWrite(output);
+            endWrite(response);
         }
         catch (Exception x)
         {
@@ -168,14 +168,14 @@ public abstract class AbstractStreamHttpTransport extends AbstractHttpTransport
         }
     }
 
-    protected void writeMessage(ServletOutputStream output, ServerSessionImpl session, ServerMessage message) throws IOException
+    protected void writeMessage(HttpServletResponse response, ServerSessionImpl session, ServerMessage message) throws IOException
     {
-        output.print(message.getJSON());
+        response.getOutputStream().write(message.getJSON().getBytes(response.getCharacterEncoding()));
     }
 
     protected abstract ServletOutputStream beginWrite(HttpServletRequest request, HttpServletResponse response) throws IOException;
 
-    protected abstract void endWrite(ServletOutputStream output) throws IOException;
+    protected abstract void endWrite(HttpServletResponse response) throws IOException;
 
     protected class DispatchingLongPollScheduler extends LongPollScheduler
     {

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/JSONPTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/JSONPTransport.java
@@ -80,15 +80,16 @@ public class JSONPTransport extends AbstractStreamHttpTransport
         response.setContentType(_mimeType);
         String callback = request.getParameter(_callbackParam);
         ServletOutputStream output = response.getOutputStream();
-        output.print(callback);
-        output.print("([");
+        output.write(callback.getBytes(response.getCharacterEncoding()));
+        output.write("([".getBytes(response.getCharacterEncoding()));
         return output;
     }
 
     @Override
-    protected void endWrite(ServletOutputStream output) throws IOException
+    protected void endWrite(HttpServletResponse response) throws IOException
     {
-        output.print("])");
+        ServletOutputStream output = response.getOutputStream();
+        output.write("])".getBytes(response.getCharacterEncoding()));
         output.close();
     }
 

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/JSONTransport.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/transport/JSONTransport.java
@@ -73,14 +73,15 @@ public class JSONTransport extends AbstractStreamHttpTransport
     {
         response.setContentType(_mimeType);
         ServletOutputStream output = response.getOutputStream();
-        output.print("[");
+        output.write("[".getBytes(response.getCharacterEncoding()));
         return output;
     }
 
     @Override
-    protected void endWrite(ServletOutputStream output) throws IOException
+    protected void endWrite(HttpServletResponse response) throws IOException
     {
-        output.print("]");
+        ServletOutputStream output = response.getOutputStream();
+        output.write("]".getBytes(response.getCharacterEncoding()));
         output.close();
     }
 }

--- a/cometd-java/cometd-java-server/src/test/java/org/cometd/server/SlowConnectionTest.java
+++ b/cometd-java/cometd-java-server/src/test/java/org/cometd/server/SlowConnectionTest.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
 
 import org.cometd.bayeux.Channel;
 import org.cometd.bayeux.Message;
@@ -186,7 +186,7 @@ public class SlowConnectionTest extends AbstractBayeuxClientServerTest
         JSONTransport transport = new JSONTransport(bayeux)
         {
             @Override
-            protected void writeMessage(ServletOutputStream output, ServerSessionImpl session, ServerMessage message) throws IOException
+            protected void writeMessage(HttpServletResponse response, ServerSessionImpl session, ServerMessage message) throws IOException
             {
                 try
                 {
@@ -195,7 +195,7 @@ public class SlowConnectionTest extends AbstractBayeuxClientServerTest
                         session.startIntervalTimeout(0);
                         TimeUnit.MILLISECONDS.sleep(2 * maxInterval);
                     }
-                    super.writeMessage(output, session, message);
+                    super.writeMessage(response, session, message);
                 }
                 catch (InterruptedException x)
                 {
@@ -263,7 +263,7 @@ public class SlowConnectionTest extends AbstractBayeuxClientServerTest
         final JSONTransport transport = new JSONTransport(bayeux)
         {
             @Override
-            protected void writeMessage(ServletOutputStream output, ServerSessionImpl session, ServerMessage message) throws IOException
+            protected void writeMessage(HttpServletResponse response, ServerSessionImpl session, ServerMessage message) throws IOException
             {
                 if (!message.isMeta() && !message.isPublishReply())
                 {
@@ -272,7 +272,7 @@ public class SlowConnectionTest extends AbstractBayeuxClientServerTest
                     // Simulate that an exception is being thrown while writing
                     throw new EofException("test_exception");
                 }
-                super.writeMessage(output, session, message);
+                super.writeMessage(response, session, message);
             }
         };
         transport.init();


### PR DESCRIPTION
Ensures UTF8 compatibility with containers that do not use an encoder during `ServletOutputStream.print(String)`

See: http://bugs.cometd.org/browse/COMETD-565
