### PR TITLE
Fixed type mismatch error in BayeuxServerImpl 

### DIFF
--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -109,7 +109,7 @@ public class BayeuxServerImpl extends AbstractLifeCycle implements BayeuxServer
     private final ConcurrentMap<String, ServerChannelImpl> _channels = new ConcurrentHashMap<>();
     private final Map<String, ServerTransport> _transports = new LinkedHashMap<>(); // Order is important
     private final List<String> _allowedTransports = new ArrayList<>();
-    private final ThreadLocal<AbstractServerTransport> _currentTransport = new ThreadLocal<>();
+    private final ThreadLocal<ServerTransport> _currentTransport = new ThreadLocal<>();
     private final Map<String, Object> _options = new TreeMap<>();
     private final Scheduler _scheduler = new ScheduledExecutorScheduler("BayeuxServer" + hashCode() + " Scheduler", false);
     private SecurityPolicy _policy = new DefaultSecurityPolicy();
@@ -386,7 +386,7 @@ public class BayeuxServerImpl extends AbstractLifeCycle implements BayeuxServer
         return _random.nextLong();
     }
 
-    public void setCurrentTransport(AbstractServerTransport transport)
+    public void setCurrentTransport(ServerTransport transport)
     {
         _currentTransport.set(transport);
     }


### PR DESCRIPTION
The getter and setter must interact with the same type. Spring/Java 8 could not Autowire a BayeuxServer without this fix.

the old method got a ServerTransport but set an AbstractServerTransport. This was a fail in Spring 3.2.3/Java 8. 