### PR TITLE
COMETD-591 - Replace ConcurrentHashMap with HashMap in the AcknowledgedMessagesSessionExtension class

### DIFF
--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/ext/AcknowledgedMessagesSessionExtension.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/ext/AcknowledgedMessagesSessionExtension.java
@@ -15,9 +15,9 @@
  */
 package org.cometd.server.ext;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.cometd.bayeux.Channel;
 import org.cometd.bayeux.server.ServerMessage;
@@ -35,7 +35,7 @@ public class AcknowledgedMessagesSessionExtension implements Extension, ServerSe
 {
     private static final Logger _logger = LoggerFactory.getLogger(AcknowledgedMessagesSessionExtension.class);
 
-    private final Map<Long, Long> _batches = new ConcurrentHashMap<>();
+    private final Map<Long, Long> _batches = new HashMap<>();
     private final ServerSessionImpl _session;
     private final BatchArrayQueue<ServerMessage> _queue;
     private long _lastBatch;


### PR DESCRIPTION
Replaced ConcurrentHashMap with HashMap since every access to the "_batches" instance field is guarded by the ServerSessionImpl lock.

Signed-off-by: fabriziocucci <fabrizio.cucci@yahoo.com>