### PR TITLE
#665 Make sure 'setTimeout' exists within the context

### DIFF
--- a/cometd-javascript/common/src/main/js/org/cometd/WebSocketTransport.js
+++ b/cometd-javascript/common/src/main/js/org/cometd/WebSocketTransport.js
@@ -155,7 +155,7 @@ org.cometd.WebSocketTransport = function() {
                 var message = envelope.messages[i];
                 if (message.id) {
                     messageIds.push(message.id);
-                    context.timeouts[message.id] = this.setTimeout(function() {
+                    context.timeouts[message.id] = self.setTimeout(function() {
                         _cometd._debug('Transport', self.getType(), 'timing out message', message.id, 'after', delay, 'on', context);
                         _forceClose.call(self, context, {code: 1000, reason: 'Message Timeout'});
                     }, delay);


### PR DESCRIPTION
This PR refers to the issue raised by me last Friday (https://github.com/cometd/cometd/issues/665)
I've used `self` instead of `function(){ ... }.bind(this)` as self was previously defined.