### PR TITLE
Use archetype plugin v2.x

### DIFF
--- a/cometd-documentation/src/main/asciidoc/primer.adoc
+++ b/cometd-documentation/src/main/asciidoc/primer.adoc
@@ -42,7 +42,7 @@ file (otherwise you will get a Maven error), for example an empty directory:
 
 ----
 $ cd /tmp
-$ mvn archetype:generate -DarchetypeCatalog=http://cometd.org
+$ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeCatalog=http://cometd.org
 ...
 Choose archetype:
 1: local -> org.cometd.archetypes:cometd-archetype-dojo-jetty9


### PR DESCRIPTION
Maven's archetype plugin v3.x does not seem to work with remote catalogs. Specify a 2.x version explicitly when calling the archetype plugin to avoid confusion with new users.