### PR TITLE
Do not reuse webapp directory roots during the same JVM

### DIFF
--- a/cometd-java/cometd-java-oort/src/test/resources/xjetty-websocket-httpclient.xml
+++ b/cometd-java/cometd-java-oort/src/test/resources/xjetty-websocket-httpclient.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<!--
+
+This will ensure that the HttpClient used by the various Transports
+are all the same instance (and threadpool, and bufferpool, etc).
+
+Note: JSR356 client has an HttpClient that doesn't shutdown/stop.
+So running JSR356 then Jetty Native WebSocket means you will run out
+of threads rather quickly.
+
+ -->
+<Configure class="org.eclipse.jetty.client.HttpClient">
+  <Arg>
+    <New class="org.eclipse.jetty.util.ssl.SslContextFactory">
+      <Set name="trustAll" type="java.lang.Boolean">false</Set>
+    </New>
+  </Arg>
+  <Set name="connectTimeout">5555</Set>
+  <Set name="executor">
+    <New class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+      <Set name="name">XmlBasedClient@</Set>
+    </New>
+  </Set>
+</Configure>

--- a/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/WebAppTest.java
+++ b/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/WebAppTest.java
@@ -59,9 +59,14 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 public class WebAppTest {
+    @Rule
+    public TestName testname = new TestName();
+
     private Path baseDir;
     private Server server;
     private ServerConnector connector;
@@ -76,7 +81,7 @@ public class WebAppTest {
     }
 
     private void start(Path webXML) throws Exception {
-        Path contextDir = baseDir.resolve("target/test-webapp");
+        Path contextDir = baseDir.resolve("target/test-webapp/" + testname.getMethodName());
         Path webINF = contextDir.resolve("WEB-INF");
         Path lib = webINF.resolve("lib");
 


### PR DESCRIPTION
 * Some FileSystem types do not support this kind of quick delete
   and reuse from the same JVM (MS Windows) for WebAppContext.