### PR TITLE
Issue #739 - Nashorn scripts being held through `inheritedAccessControlContext` of pooled threads.

### DIFF
--- a/cometd-javascript/common-test/src/main/java/org/cometd/javascript/JavaScript.java
+++ b/cometd-javascript/common-test/src/main/java/org/cometd/javascript/JavaScript.java
@@ -154,6 +154,10 @@ public class JavaScript implements Runnable {
         return (T)bindings.get(key);
     }
 
+    public void putAsync(String key, Object value) {
+        bindings.put(key, value);
+    }
+
     private void submit(FutureTask<?> task) {
         if (Thread.currentThread() == thread) {
             task.run();

--- a/cometd-javascript/common-test/src/main/resources/browser.js
+++ b/cometd-javascript/common-test/src/main/resources/browser.js
@@ -157,7 +157,6 @@ var Latch = Java.type('org.cometd.javascript.Latch');
 
 
     // Timers
-    var _scheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor();
     window.setTimeout = function(fn, delay) {
         delay = delay || 0;
         return _scheduler.schedule(new java.lang.Runnable({


### PR DESCRIPTION
* Moves _scheduler from browser.js into AbstractCometDTest, uses a privileged ThreadFactory with it, and ensures it's shut down after the test.
* Additionally, loads browser.js as a local classpath resource so it's not recompiled every time and eliminates the inline one-liner window_location script.

With these changes, `mvn test` in `cometd-javascript` completes in 14 minutes with acceptable memory use throughout.

With jQuery provider there are no test failures, it logs:
```
[WARNING] Tests run: 124, Failures: 0, Errors: 0, Skipped: 2
```
With Dojo provider it reports two test failures:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   CometDPublishTest.testPublishWithServerDownInvokesCallback:127->AbstractCometDTest.disconnect:268
[ERROR]   CometDDojoHitchTest.testDojoHitch:31
[INFO] 
[ERROR] Tests run: 125, Failures: 2, Errors: 0, Skipped: 3
```
