### PR TITLE
Issue #762 consistent JSONDataFilter

### DIFF
--- a/cometd-java/cometd-java-examples/src/main/java/org/cometd/examples/ChatService.java
+++ b/cometd-java/cometd-java-examples/src/main/java/org/cometd/examples/ChatService.java
@@ -34,6 +34,7 @@ import org.cometd.annotation.Session;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ConfigurableServerChannel;
+import org.cometd.bayeux.server.ServerChannel;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.authorizer.GrantAuthorizer;
@@ -155,9 +156,9 @@ public class ChatService {
 
     class BadWordFilter extends JSONDataFilter {
         @Override
-        protected Object filterString(String string) {
+        protected Object filterString(ServerSession session, ServerChannel channel, String string) {
             if (string.contains("dang")) {
-                throw new DataFilter.Abort();
+                throw new DataFilter.AbortException();
             }
             return string;
         }

--- a/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/OortChatService.java
+++ b/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/OortChatService.java
@@ -38,6 +38,7 @@ import org.cometd.annotation.Session;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ConfigurableServerChannel;
+import org.cometd.bayeux.server.ServerChannel;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.authorizer.GrantAuthorizer;
@@ -173,9 +174,9 @@ public class OortChatService {
 
     class BadWordFilter extends JSONDataFilter {
         @Override
-        protected Object filterString(String string) {
+        protected Object filterString(ServerSession session, ServerChannel channel, String string) {
             if (string.contains("dang")) {
-                throw new DataFilter.Abort();
+                throw new DataFilter.AbortException();
             }
             return string;
         }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/DataFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/DataFilter.java
@@ -15,23 +15,58 @@
  */
 package org.cometd.server.filter;
 
+import org.cometd.bayeux.Message;
 import org.cometd.bayeux.server.ServerChannel;
 import org.cometd.bayeux.server.ServerSession;
 
+/**
+ * <p>A filter that can add, modify or remove fields from the
+ * {@link Message#getData() message data}.</p>
+ */
 public interface DataFilter {
     /**
-     * @param from    the {@link ServerSession} that sends the data
-     * @param channel the channel the data is being sent to
+     * <p>Modifies the given message data.</p>
+     * <p>Returning {@code null} or throwing {@link AbortException}
+     * results in the message processing being interrupted
+     * and the message itself discarded.</p>
+     * <p>If the returned object is different (as returned by
+     * the {@code !=} operator) from the {@code data} parameter
+     * then it is set as the new message data via
+     * {@link Message.Mutable#setData(Object)}.</p>
+     *
+     * @param session the {@link ServerSession} that sends the data
+     * @param channel the channel the data is being sent on
      * @param data    the data being sent
-     * @return the transformed data or null if the message should be aborted
+     * @return the transformed data or null if the message should be ignored
+     * @throws AbortException to abort the filtering of the data
      */
-    public abstract Object filter(ServerSession from, ServerChannel channel, Object data);
-
+    public abstract Object filter(ServerSession session, ServerChannel channel, Object data) throws AbortException;
 
     /**
-     * Abort the message by throwing this exception
+     * <p>Aborts the filtering of the message data.</p>
      */
-    public class Abort extends RuntimeException {
+    public static class AbortException extends RuntimeException {
+        public AbortException() {
+        }
+
+        public AbortException(String message) {
+            super(message);
+        }
+
+        public AbortException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public AbortException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    /**
+     * @deprecated use {@link AbortException} instead
+     */
+    @Deprecated
+    public class Abort extends AbortException {
         public Abort() {
             super();
         }
@@ -43,6 +78,5 @@ public interface DataFilter {
         public Abort(String msg, Throwable cause) {
             super(msg, cause);
         }
-
     }
 }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/DataFilterMessageListener.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/DataFilterMessageListener.java
@@ -55,7 +55,7 @@ public class DataFilterMessageListener implements ServerChannel.MessageListener 
                 message.setData(data);
             }
             return true;
-        } catch (DataFilter.Abort a) {
+        } catch (DataFilter.AbortException a) {
             if (_logger.isDebugEnabled()) {
                 _logger.debug("", a);
             }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/JSONDataFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/JSONDataFilter.java
@@ -16,9 +16,14 @@
 package org.cometd.server.filter;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.cometd.bayeux.server.ServerChannel;
 import org.cometd.bayeux.server.ServerSession;
@@ -41,12 +46,11 @@ public class JSONDataFilter implements DataFilter {
         if (data == null) {
             return null;
         }
-
         if (data instanceof Map) {
             return filterMap(from, to, (Map)data);
         }
         if (data instanceof List) {
-            return filterArray(from, to, ((List)data).toArray());
+            return filterList(from, to, (List)data);
         }
         if (data instanceof Collection) {
             return filterArray(from, to, ((Collection)data).toArray());
@@ -83,29 +87,87 @@ public class JSONDataFilter implements DataFilter {
             return null;
         }
 
-        int length = Array.getLength(array);
-
-        for (int i = 0; i < length; i++) {
-            Array.set(array, i, filter(from, to, Array.get(array, i)));
+        Object[] mutated = null;        
+        for (int i=Array.getLength(array); i-->0;) {
+            Object original = Array.get(array,i);
+            Object filtered = filter(from, to , original);
+            if (original!=filtered) {
+                if (mutated==null)
+                    mutated=Arrays.copyOf((Object[])array,Array.getLength(array));
+                mutated[i] = filtered;
+            }
         }
 
-        return array;
+        return mutated==null?array:mutated;
     }
 
-    protected Object filterMap(ServerSession from, ServerChannel to, Map<String, Object> map) {
+    protected Object filterList(ServerSession from, ServerChannel to, List<Object> list) {
+        if (list == null) {
+            return null;
+        }
+
+        List<Object> mutated = null;
+        for (int i=list.size(); i-->0;) {
+            Object original = list.get(i);
+            Object filtered = filter(from, to ,original);
+            if (original!=filtered) {
+                if (mutated==null)
+                    mutated = new ArrayList<>(list);
+                mutated.set(i,filtered);
+            }
+        }
+            
+        return mutated==null?list:mutated;
+    }
+    
+    protected Object filterCollection(ServerSession from, ServerChannel to, Collection<Object> collection) {
+        if (collection == null) {
+            return null;
+        }
+
+        List<Object> mutated = null;
+        for (Iterator<Object> i = collection.iterator(); i.hasNext();) {
+            Object original = i.next();
+            Object filtered = filter(from, to ,original);
+            if (original!=filtered) {
+                if (mutated==null) {
+                    mutated = new ArrayList<>(collection.size());
+                    for (Object copy : collection) {
+                        if (copy==original)
+                            break;
+                        mutated.add(copy);
+                    }
+                }
+                
+                mutated.add(filtered);
+            }
+            else if (mutated!=null) {
+                mutated.add(original);
+            }
+        }
+         
+        return mutated==null?collection:mutated;
+    }
+
+    
+        
+    protected Object filterMap(ServerSession from, ServerChannel to, Map<Object, Object> map) {
         if (map == null) {
             return null;
         }
 
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
+        Map<Object, Object> mutated = null;
+        for (Entry<Object, Object> entry : map.entrySet()) {
             Object original = entry.getValue();
             Object filtered = filter(from, to ,original);
             if (original!=filtered) {
-                entry.setValue(filtered);
+                if (mutated==null)
+                    mutated = new HashMap<>(map);
+                mutated.put(entry.getKey(),filtered);
             }
         }
-
-        return map;
+            
+        return mutated==null?map:mutated;
     }
 
     protected Object filterObject(ServerSession from, ServerChannel to, Object obj) {

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/JSONDataFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/JSONDataFilter.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,9 +29,11 @@ import org.cometd.bayeux.server.ServerSession;
 
 /**
  * <p>{@link JSONDataFilter} walks an object to see if it is a JSON data structure
- * and calls the appropriate protected method {@link #filterString(String)},
+ * and calls the appropriate methods {@link #filterString(String)},
  * {@link #filterNumber(Number)}, {@link #filterBoolean(Boolean)},
- * {@link #filterArray(ServerSession, ServerChannel, Object)} or
+ * {@link #filterArray(ServerSession, ServerChannel, Object)},
+ * {@link #filterCollection(ServerSession, ServerChannel, Collection)},
+ * {@link #filterList(ServerSession, ServerChannel, List)},
  * {@link #filterMap(ServerSession, ServerChannel, Map)}.</p>
  * <p>Derived filters may override one or more of these methods to provide
  * filtering of specific types.</p>
@@ -42,135 +43,142 @@ public class JSONDataFilter implements DataFilter {
     }
 
     @Override
-    public Object filter(ServerSession from, ServerChannel to, Object data) {
+    public Object filter(ServerSession session, ServerChannel channel, Object data) {
         if (data == null) {
             return null;
         }
         if (data instanceof Map) {
-            return filterMap(from, to, (Map)data);
+            return filterMap(session, channel, (Map)data);
         }
         if (data instanceof List) {
-            return filterList(from, to, (List)data);
+            return filterList(session, channel, (List)data);
         }
         if (data instanceof Collection) {
-            return filterArray(from, to, ((Collection)data).toArray());
+            return filterCollection(session, channel, (Collection)data);
         }
         if (data.getClass().isArray()) {
-            return filterArray(from, to, data);
+            return filterArray(session, channel, data);
         }
         if (data instanceof Number) {
-            return filterNumber((Number)data);
+            return filterNumber(session, channel, (Number)data);
         }
         if (data instanceof Boolean) {
-            return filterBoolean((Boolean)data);
+            return filterBoolean(session, channel, (Boolean)data);
         }
         if (data instanceof String) {
-            return filterString((String)data);
+            return filterString(session, channel, (String)data);
         }
-        return filterObject(from, to, data);
+        return filterObject(session, channel, data);
     }
 
+    protected Object filterString(ServerSession session, ServerChannel channel, String string) {
+        return filterString(string);
+    }
+
+    /**
+     * @deprecated use {@link #filterString(ServerSession, ServerChannel, String)} instead
+     */
+    @Deprecated
     protected Object filterString(String string) {
         return string;
     }
 
+    protected Object filterBoolean(ServerSession session, ServerChannel channel, Boolean bool) {
+        return filterBoolean(bool);
+    }
+
+    /**
+     * @deprecated use {@link #filterBoolean(ServerSession, ServerChannel, Boolean)} instead
+     */
+    @Deprecated
     protected Object filterBoolean(Boolean bool) {
         return bool;
     }
 
+    protected Object filterNumber(ServerSession session, ServerChannel channel, Number number) {
+        return filterNumber(number);
+    }
+
+    /**
+     * @deprecated use {@link #filterNumber(ServerSession, ServerChannel, Number)} instead
+     */
+    @Deprecated
     protected Object filterNumber(Number number) {
         return number;
     }
 
-    protected Object filterArray(ServerSession from, ServerChannel to, Object array) {
-        if (array == null) {
-            return null;
-        }
-
-        Object[] mutated = null;        
-        for (int i=Array.getLength(array); i-->0;) {
-            Object original = Array.get(array,i);
-            Object filtered = filter(from, to , original);
-            if (original!=filtered) {
-                if (mutated==null)
-                    mutated=Arrays.copyOf((Object[])array,Array.getLength(array));
+    protected Object filterArray(ServerSession session, ServerChannel channel, Object array) {
+        Object[] mutated = null;
+        for (int i = 0; i < Array.getLength(array); ++i) {
+            Object original = Array.get(array, i);
+            Object filtered = filter(session, channel, original);
+            if (original != filtered) {
+                if (mutated == null) {
+                    mutated = Arrays.copyOf((Object[])array, Array.getLength(array));
+                }
                 mutated[i] = filtered;
             }
         }
-
-        return mutated==null?array:mutated;
+        return mutated == null ? array : mutated;
     }
 
-    protected Object filterList(ServerSession from, ServerChannel to, List<Object> list) {
-        if (list == null) {
-            return null;
-        }
-
+    protected Object filterList(ServerSession session, ServerChannel channel, List<Object> list) {
         List<Object> mutated = null;
-        for (int i=list.size(); i-->0;) {
+        for (int i = 0; i < list.size(); ++i) {
             Object original = list.get(i);
-            Object filtered = filter(from, to ,original);
-            if (original!=filtered) {
-                if (mutated==null)
+            Object filtered = filter(session, channel, original);
+            if (original != filtered) {
+                if (mutated == null) {
                     mutated = new ArrayList<>(list);
-                mutated.set(i,filtered);
+                }
+                mutated.set(i, filtered);
             }
         }
-            
-        return mutated==null?list:mutated;
+        return mutated == null ? list : mutated;
     }
-    
-    protected Object filterCollection(ServerSession from, ServerChannel to, Collection<Object> collection) {
-        if (collection == null) {
-            return null;
-        }
 
+    protected Object filterCollection(ServerSession session, ServerChannel channel, Collection<Object> collection) {
+        int index = 0;
         List<Object> mutated = null;
-        for (Iterator<Object> i = collection.iterator(); i.hasNext();) {
-            Object original = i.next();
-            Object filtered = filter(from, to ,original);
-            if (original!=filtered) {
-                if (mutated==null) {
+        for (Object original : collection) {
+            Object filtered = filter(session, channel, original);
+            if (original != filtered) {
+                if (mutated == null) {
                     mutated = new ArrayList<>(collection.size());
+                    int i = 0;
                     for (Object copy : collection) {
-                        if (copy==original)
+                        if (i == index) {
                             break;
+                        }
                         mutated.add(copy);
+                        ++i;
                     }
                 }
-                
                 mutated.add(filtered);
-            }
-            else if (mutated!=null) {
+            } else if (mutated != null) {
                 mutated.add(original);
             }
+            ++index;
         }
-         
-        return mutated==null?collection:mutated;
+        return mutated == null ? collection : mutated;
     }
 
-    
-        
-    protected Object filterMap(ServerSession from, ServerChannel to, Map<Object, Object> map) {
-        if (map == null) {
-            return null;
-        }
-
-        Map<Object, Object> mutated = null;
-        for (Entry<Object, Object> entry : map.entrySet()) {
+    protected Object filterMap(ServerSession session, ServerChannel channel, Map<String, Object> map) {
+        Map<String, Object> mutated = null;
+        for (Entry<String, Object> entry : map.entrySet()) {
             Object original = entry.getValue();
-            Object filtered = filter(from, to ,original);
-            if (original!=filtered) {
-                if (mutated==null)
+            Object filtered = filter(session, channel, original);
+            if (original != filtered) {
+                if (mutated == null) {
                     mutated = new HashMap<>(map);
-                mutated.put(entry.getKey(),filtered);
+                }
+                mutated.put(entry.getKey(), filtered);
             }
         }
-            
-        return mutated==null?map:mutated;
+        return mutated == null ? map : mutated;
     }
 
-    protected Object filterObject(ServerSession from, ServerChannel to, Object obj) {
-        return obj;
+    protected Object filterObject(ServerSession session, ServerChannel channel, Object data) {
+        return data;
     }
 }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/NoMarkupFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/NoMarkupFilter.java
@@ -17,14 +17,16 @@ package org.cometd.server.filter;
 
 import java.util.regex.Pattern;
 
+import org.cometd.bayeux.server.ServerChannel;
+import org.cometd.bayeux.server.ServerSession;
+
 public class NoMarkupFilter extends JSONDataFilter {
     private static Pattern __open = Pattern.compile("<");
     private static Pattern __close = Pattern.compile(">");
 
     @Override
-    protected Object filterString(String string) {
+    protected Object filterString(ServerSession session, ServerChannel channel, String string) {
         string = __open.matcher(string).replaceAll("&lt;");
-        string = __close.matcher(string).replaceAll("&gt;");
-        return string;
+        return __close.matcher(string).replaceAll("&gt;");
     }
 }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/NoScriptsFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/NoScriptsFilter.java
@@ -15,20 +15,18 @@
  */
 package org.cometd.server.filter;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.jetty.util.StringUtil;
+import org.cometd.bayeux.server.ServerChannel;
+import org.cometd.bayeux.server.ServerSession;
 
 public class NoScriptsFilter extends JSONDataFilter {
-    private static Pattern __script = Pattern.compile("<\\s*[Ss][Cc][Rr][Ii][Pp][Tt]");
+    private static Pattern __scriptBegin = Pattern.compile("<\\s*[Ss][Cc][Rr][Ii][Pp][Tt]");
+    private static Pattern __scriptEnd = Pattern.compile("[Ss][Cc][Rr][Ii][Pp][Tt]\\s*>");
 
     @Override
-    protected Object filterString(String string) {
-        Matcher m = __script.matcher(string);
-        if (m.matches()) {
-            string = StringUtil.replace(string, "script", "span");
-        }
-        return string;
+    protected Object filterString(ServerSession session, ServerChannel channel, String string) {
+        string = __scriptBegin.matcher(string).replaceAll("<span");
+        return __scriptEnd.matcher(string).replaceAll("span>");
     }
 }

--- a/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/RegexFilter.java
+++ b/cometd-java/cometd-java-server/src/main/java/org/cometd/server/filter/RegexFilter.java
@@ -18,15 +18,25 @@ package org.cometd.server.filter;
 import java.lang.reflect.Array;
 import java.util.regex.Pattern;
 
+import org.cometd.bayeux.server.ServerChannel;
+import org.cometd.bayeux.server.ServerSession;
+
 public class RegexFilter extends JSONDataFilter {
     protected String[] _templates;
     protected String[] _replaces;
-    protected transient Pattern[] _patterns;
+    protected Pattern[] _patterns;
 
     /**
-     * Assumes the init object is an Array of 2 element Arrays:
-     * [regex,replacement]. if the regex replacement string is null, then an
-     * IllegalStateException is thrown if the pattern matches.
+     * <p>The {@code init} object must be an array of array of this form:</p>
+     * <pre>
+     * [
+     *     [regex1, replacement1],
+     *     [regex2, replacement2],
+     *     ...
+     * ]
+     * </pre>
+     * <p>If the {@code replacement} string is null, then an
+     * {@link AbortException} is thrown if the pattern matches.
      */
     @Override
     public void init(Object init) {
@@ -41,29 +51,19 @@ public class RegexFilter extends JSONDataFilter {
             _replaces[i] = (String)Array.get(entry, 1);
         }
 
-        checkPatterns();
-    }
-
-    protected void checkPatterns() {
-        synchronized (this) {
-            if (_patterns == null) {
-                _patterns = new Pattern[_templates.length];
-                for (int i = 0; i < _patterns.length; i++) {
-                    _patterns[i] = Pattern.compile(_templates[i]);
-                }
-            }
+        _patterns = new Pattern[_templates.length];
+        for (int i = 0; i < _patterns.length; i++) {
+            _patterns[i] = Pattern.compile(_templates[i]);
         }
     }
 
     @Override
-    protected Object filterString(String string) {
-        checkPatterns();
-
+    protected Object filterString(ServerSession session, ServerChannel channel, String string) {
         for (int i = 0; i < _patterns.length; i++) {
             if (_replaces[i] != null) {
                 string = _patterns[i].matcher(string).replaceAll(_replaces[i]);
             } else if (_patterns[i].matcher(string).matches()) {
-                throw new IllegalStateException("matched " + _patterns[i] + " in " + string);
+                throw new AbortException("matched " + _patterns[i] + " in " + string);
             }
         }
         return string;

--- a/cometd-java/cometd-java-server/src/test/java/org/cometd/server/filter/JSONDataFilterTest.java
+++ b/cometd-java/cometd-java-server/src/test/java/org/cometd/server/filter/JSONDataFilterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.server.filter;
+
+import java.util.Collections;
+
+import org.cometd.bayeux.server.ConfigurableServerChannel;
+import org.cometd.bayeux.server.ServerChannel;
+import org.cometd.bayeux.server.ServerMessage;
+import org.cometd.bayeux.server.ServerSession;
+import org.cometd.server.AbstractBayeuxClientServerTest;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JSONDataFilterTest extends AbstractBayeuxClientServerTest {
+    public JSONDataFilterTest(String serverTransport) {
+        super(serverTransport);
+    }
+
+    @Test
+    public void testImmutableData() throws Exception {
+        startServer(null);
+
+        final String filtered = "/filtered";
+        bayeux.createChannelIfAbsent(filtered, new ConfigurableServerChannel.Initializer() {
+            @Override
+            public void configureChannel(ConfigurableServerChannel channel) {
+                channel.addListener(new DataFilterMessageListener(new NoScriptsFilter()));
+            }
+        });
+
+        String unfiltered = "/service/unfiltered";
+        bayeux.createChannelIfAbsent(unfiltered).getReference().addListener(new ServerChannel.MessageListener() {
+            @Override
+            public boolean onMessage(ServerSession session, ServerChannel channel, ServerMessage.Mutable message) {
+                bayeux.getChannel(filtered).publish(session, Collections.unmodifiableMap(message.getDataAsMap()));
+                return true;
+            }
+        });
+
+        Request handshake = newBayeuxRequest("[{" +
+                "\"channel\": \"/meta/handshake\"," +
+                "\"version\": \"1.0\"," +
+                "\"supportedConnectionTypes\": [\"long-polling\"]" +
+                "}]");
+        ContentResponse response = handshake.send();
+        Assert.assertEquals(200, response.getStatus());
+
+        String clientId = extractClientId(response);
+
+        Request connect = newBayeuxRequest("[{" +
+                "\"channel\": \"/meta/connect\"," +
+                "\"clientId\": \"" + clientId + "\"," +
+                "\"connectionType\": \"long-polling\"" +
+                "}]");
+        response = connect.send();
+        Assert.assertEquals(200, response.getStatus());
+
+        Request subscribe = newBayeuxRequest("[{" +
+                "\"channel\": \"/meta/subscribe\"," +
+                "\"clientId\": \"" + clientId + "\"," +
+                "\"subscription\": \"" + filtered + "\"" +
+                "}]");
+        response = subscribe.send();
+        Assert.assertEquals(200, response.getStatus());
+
+        String script = "<script>alert()</script>";
+        Request publish = newBayeuxRequest("[{" +
+                "\"channel\": \"" + unfiltered + "\"," +
+                "\"clientId\": \"" + clientId + "\"," +
+                "\"data\": {" +
+                "    \"message\": \"" + script + "\"" +
+                "}" +
+                "}]");
+        response = publish.send();
+        Assert.assertEquals(200, response.getStatus());
+
+        String json = response.getContentAsString();
+        String expected = script.replaceAll("script", "span");
+        Assert.assertTrue(json.contains(expected));
+    }
+}


### PR DESCRIPTION
Fix for #762.  Data containers (lists, arrays, maps, collections) are never mutated.  If a filter changes a value then a new container is created.   This avoids needless array creation and updates and is more consistent.

Signed-off-by: Greg Wilkins <gregw@webtide.com>