### PR TITLE
Issue #807 - OkHttp-based implementation of client AbstractWebSocketTransport

### DIFF
--- a/cometd-java/cometd-java-tests/pom.xml
+++ b/cometd-java/cometd-java-tests/pom.xml
@@ -85,6 +85,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.cometd.java</groupId>
+      <artifactId>cometd-java-websocket-okhttp-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/HandshakeReconnectTest.java
+++ b/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/HandshakeReconnectTest.java
@@ -15,11 +15,8 @@
  */
 package org.cometd.tests;
 
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.cometd.bayeux.Channel;
+import org.cometd.bayeux.Message;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
@@ -28,6 +25,11 @@ import org.cometd.client.BayeuxClient;
 import org.cometd.server.AbstractServerTransport;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class HandshakeReconnectTest extends AbstractClientServerTest {
     public HandshakeReconnectTest(Transport transport) {
@@ -43,8 +45,14 @@ public class HandshakeReconnectTest extends AbstractClientServerTest {
         options.put(AbstractServerTransport.TIMEOUT_OPTION, String.valueOf(timeout));
         options.put(AbstractServerTransport.MAX_INTERVAL_OPTION, String.valueOf(maxInterval));
         startServer(options);
-
-        BayeuxClient client = newBayeuxClient();
+        final CountDownLatch handshakeReconnect = new CountDownLatch(1);
+        BayeuxClient client = new BayeuxClient(cometdURL, newClientTransport(null)) {
+            @Override
+            public void onFailure(Throwable failure, List<? extends Message> messages) {
+                logger.error("failure with messages {}", messages, failure);
+                handshakeReconnect.countDown();
+            }
+        };
         client.handshake();
         Assert.assertTrue(client.waitFor(5000, BayeuxClient.State.CONNECTED));
 
@@ -56,7 +64,7 @@ public class HandshakeReconnectTest extends AbstractClientServerTest {
         connector.stop();
 
         // Add a /meta/handshake listener to be sure we reconnect using handshake.
-        final CountDownLatch handshakeReconnect = new CountDownLatch(1);
+
         client.getChannel(Channel.META_HANDSHAKE).addListener((ClientSessionChannel.MessageListener)(channel, message) -> {
             // Reconnecting using handshake, first failure.
             if (!message.isSuccessful()) {
@@ -84,8 +92,9 @@ public class HandshakeReconnectTest extends AbstractClientServerTest {
         connector.setPort(port);
         connector.start();
 
-        Assert.assertTrue(client.waitFor(20 * client.getBackoffIncrement(), BayeuxClient.State.CONNECTED));
+        Assert.assertTrue(client.waitFor(30 * client.getBackoffIncrement(), BayeuxClient.State.CONNECTED));
 
         disconnectBayeuxClient(client);
     }
+
 }

--- a/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/MaxMessageSizeTest.java
+++ b/cometd-java/cometd-java-tests/src/test/java/org/cometd/tests/MaxMessageSizeTest.java
@@ -15,12 +15,6 @@
  */
 package org.cometd.tests;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.cometd.bayeux.Promise;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.client.BayeuxClient;
@@ -28,6 +22,12 @@ import org.cometd.client.transport.ClientTransport;
 import org.cometd.server.AbstractServerTransport;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class MaxMessageSizeTest extends AbstractClientServerTest {
     public MaxMessageSizeTest(Transport transport) {
@@ -67,6 +67,10 @@ public class MaxMessageSizeTest extends AbstractClientServerTest {
 
     @Test
     public void testClientMaxMessageSize() throws Exception {
+        // OkHttp has no way to override the max message size
+        if (transport == Transport.OKHTTP_WEBSOCKET) {
+            return;
+        }
         startServer(serverOptions());
 
         int maxMessageSize = 512;

--- a/cometd-java/cometd-java-websocket/cometd-java-websocket-common-client/src/main/java/org/cometd/websocket/client/common/AbstractWebSocketTransport.java
+++ b/cometd-java/cometd-java-websocket/cometd-java-websocket-common-client/src/main/java/org/cometd/websocket/client/common/AbstractWebSocketTransport.java
@@ -47,6 +47,11 @@ public abstract class AbstractWebSocketTransport extends HttpClientTransport imp
     public final static String IDLE_TIMEOUT_OPTION = "idleTimeout";
     public final static String STICKY_RECONNECT_OPTION = "stickyReconnect";
 
+    public static final int MAX_CLOSE_REASON_LENGTH = 30;
+    public static final int NORMAL_CLOSE_CODE = 1000;
+
+    protected static final String COOKIE_HEADER = "Cookie";
+
     private ScheduledExecutorService _scheduler;
     private String _protocol;
     private long _connectTimeout;

--- a/cometd-java/cometd-java-websocket/cometd-java-websocket-javax-client/src/main/java/org/cometd/websocket/client/WebSocketTransport.java
+++ b/cometd-java/cometd-java-websocket/cometd-java-websocket-javax-client/src/main/java/org/cometd/websocket/client/WebSocketTransport.java
@@ -169,7 +169,7 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
                 }
                 try {
                     // Limits of the WebSocket APIs, otherwise an exception is thrown.
-                    reason = reason.substring(0, Math.min(reason.length(), 30));
+                    reason = reason.substring(0, Math.min(reason.length(), MAX_CLOSE_REASON_LENGTH));
                     session.close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, reason));
                 } catch (Throwable x) {
                     logger.trace("Could not close websocket session " + session, x);
@@ -215,12 +215,12 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
             CookieStore cookieStore = getCookieStore();
             List<HttpCookie> cookies = cookieStore.get(URI.create(getURL()));
             if (!cookies.isEmpty()) {
-                List<String> cookieHeader = headers.get("Cookie");
+                List<String> cookieHeader = headers.get(COOKIE_HEADER);
                 if (cookieHeader == null) {
-                    cookieHeader = headers.get("cookie");
+                    cookieHeader = headers.get(COOKIE_HEADER);
                 }
                 if (cookieHeader == null) {
-                    headers.put("Cookie", cookieHeader = new ArrayList<>());
+                    headers.put(COOKIE_HEADER, cookieHeader = new ArrayList<>());
                 }
                 for (HttpCookie cookie : cookies) {
                     cookieHeader.add(cookie.getName() + "=" + cookie.getValue());

--- a/cometd-java/cometd-java-websocket/cometd-java-websocket-jetty-client/src/main/java/org/cometd/websocket/client/JettyWebSocketTransport.java
+++ b/cometd-java/cometd-java-websocket/cometd-java-websocket-jetty-client/src/main/java/org/cometd/websocket/client/JettyWebSocketTransport.java
@@ -201,7 +201,7 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport implemen
                 if (logger.isDebugEnabled()) {
                     logger.debug("Closing websocket session {}", session);
                 }
-                session.close(1000, reason);
+                session.close(NORMAL_CLOSE_CODE, reason);
             }
         }
 

--- a/cometd-java/cometd-java-websocket/cometd-java-websocket-okhttp-client/pom.xml
+++ b/cometd-java/cometd-java-websocket/cometd-java-websocket-okhttp-client/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.cometd.java</groupId>
+        <artifactId>cometd-java-websocket</artifactId>
+        <version>4.0.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cometd-java-websocket-okhttp-client</artifactId>
+    <name>CometD :: Java :: WebSocket :: OkHttp Client</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.cometd.websocket.okhttp.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cometd.java</groupId>
+            <artifactId>cometd-java-websocket-common-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/cometd-java/cometd-java-websocket/cometd-java-websocket-okhttp-client/src/main/java/org/cometd/websocket/client/OkHttpWebsocketTransport.java
+++ b/cometd-java/cometd-java-websocket/cometd-java-websocket-okhttp-client/src/main/java/org/cometd/websocket/client/OkHttpWebsocketTransport.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2008-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.websocket.client;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import org.cometd.bayeux.Message;
+import org.cometd.client.transport.ClientTransport;
+import org.cometd.client.transport.TransportListener;
+import org.cometd.websocket.client.common.AbstractWebSocketTransport;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.nio.channels.UnresolvedAddressException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class OkHttpWebsocketTransport extends AbstractWebSocketTransport {
+
+    private final OkHttpClient okHttpClient;
+
+    private boolean _webSocketSupported;
+    private boolean _webSocketConnected;
+    private final long handshakeTimeout;
+
+    private static final String SEC_WEB_SOCKET_PROTOCOL_HEADER = "Sec-WebSocket-Protocol";
+    private static final String SEC_WEB_SOCKET_ACCEPT_HEADER = "Sec-WebSocket-Accept";
+
+    // we specifically do not want to have a long blocking handshake, to allow for more request retries
+    private static final String HANDSHAKE_TIMEOUT = "handshakeTimeout";
+
+    private static final Logger log = LoggerFactory.getLogger(OkHttpWebsocketTransport.class);
+
+    public OkHttpWebsocketTransport(
+            String uri,
+            Map<String, Object> options,
+            ScheduledExecutorService scheduler,
+            OkHttpClient okHttpClient) {
+        super(uri, options, scheduler);
+        OkHttpClient.Builder enrichedClient = okHttpClient.newBuilder()
+                .connectTimeout(getConnectTimeout(), TimeUnit.MILLISECONDS);
+        if (okHttpClient.pingIntervalMillis() == 0) {
+            enrichedClient.pingInterval(20, TimeUnit.SECONDS);
+        }
+        this.okHttpClient = enrichedClient.build();
+        this._webSocketSupported = true;
+        this.handshakeTimeout = getOption(HANDSHAKE_TIMEOUT, 3_000L);
+    }
+
+    public OkHttpWebsocketTransport(
+            Map<String, Object> options,
+            OkHttpClient okHttpClient) {
+        this(null, options, null, okHttpClient);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        this._webSocketSupported = true;
+        this._webSocketConnected = false;
+    }
+
+    @Override
+    public boolean accept(String s) {
+        return _webSocketSupported;
+    }
+
+    @Override
+    protected Delegate connect(String uri, TransportListener listener, List<Message.Mutable> messages) {
+        try {
+            // We must make the okhttp call blocking for cometd to handshake properly.
+            CountDownLatch blockingOpenLatch = new CountDownLatch(1);
+            OkHttpDelegate delegate = new OkHttpDelegate(blockingOpenLatch);
+            Request upgradeReqeust = buildUpgradeRequest(uri);
+            okHttpClient.newWebSocket(upgradeReqeust, delegate.listener);
+            boolean connected = blockingOpenLatch.await(handshakeTimeout, TimeUnit.MILLISECONDS);
+            if (!connected) {
+                throw new TimeoutException(
+                        String.format("Handshake timed out waiting %sms at URL %s", handshakeTimeout, uri));
+            }
+            this._webSocketConnected = true;
+            return delegate;
+        } catch (TimeoutException | UnresolvedAddressException e) {
+            listener.onFailure(e, messages);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            listener.onFailure(e, messages);
+        } catch (Throwable e) {
+            _webSocketSupported = isStickyReconnect() && _webSocketConnected;
+            listener.onFailure(e, messages);
+        }
+        return null;
+    }
+
+    private Request buildUpgradeRequest(String uri) {
+        String protocol = getProtocol();
+        Request.Builder upgradeReqeust = new Request.Builder()
+                .url(uri);
+        if (protocol != null && !protocol.isEmpty()) {
+            upgradeReqeust.header(SEC_WEB_SOCKET_PROTOCOL_HEADER, protocol);
+        }
+        CookieStore cookieStore = getCookieStore();
+        List<HttpCookie> cookies = cookieStore.get(URI.create(uri));
+        for (HttpCookie cookie : cookies) {
+            String cookieValue = cookie.getName() + "=" + cookie.getValue();
+            upgradeReqeust.addHeader(COOKIE_HEADER, cookieValue);
+        }
+        return upgradeReqeust.build();
+    }
+
+    private class OkHttpDelegate extends Delegate {
+
+        private WebSocket webSocket;
+        private final CountDownLatch openLatch;
+        private final WebSocketListener listener = new OkHttpListener();
+
+        private OkHttpDelegate(CountDownLatch openLatch) {
+            this.openLatch = openLatch;
+        }
+
+        private void onOpen(WebSocket webSocket, Response response) {
+            synchronized (this) {
+                this.webSocket = webSocket;
+            }
+            _webSocketSupported = response.header(SEC_WEB_SOCKET_ACCEPT_HEADER) != null;
+            storeCookies(response.headers().toMultimap());
+            log.debug("Opened websocket session");
+            openLatch.countDown();
+        }
+
+        @Override
+        protected void send(String payload) {
+            final WebSocket webSocket;
+            synchronized (this) {
+                webSocket = this.webSocket;
+            }
+            try {
+                if (webSocket == null) {
+                    throw new IOException("Unconnected!");
+                }
+                boolean enqueued = webSocket.send(payload);
+                if (!enqueued) {
+                    throw new IOException("Not enqueued! Current queue size: " + webSocket.queueSize());
+                }
+            } catch (Throwable throwable) {
+                log.warn("Failure sending {}", payload, throwable);
+                fail(throwable, "Exception");
+            }
+        }
+
+        @Override
+        protected boolean isOpen() {
+            synchronized (this) {
+                return this.webSocket != null;
+            }
+        }
+
+        @Override
+        protected void close() {
+            synchronized (this) {
+                this.webSocket = null;
+            }
+        }
+
+        @Override
+        protected void shutdown(String reason) {
+            final WebSocket webSocket;
+            synchronized (this) {
+                webSocket = this.webSocket;
+                this.close();
+            }
+
+            if (webSocket != null) {
+                int code = NORMAL_CLOSE_CODE; // normal closure
+                log.debug("Closing websocket. Code: {}, Reason: {}", code, reason);
+                try {
+                    reason = reason != null
+                             ? reason.substring(0, Math.min(reason.length(), MAX_CLOSE_REASON_LENGTH))
+                             : reason;
+                    webSocket.close(code, reason);
+                } catch (Throwable t) {
+                    log.warn("Unable to close websocket connection. Code: {}, Reason: {}", code, reason, t);
+                }
+            }
+        }
+
+        private final class OkHttpListener extends WebSocketListener {
+            @Override
+            public void onOpen(WebSocket webSocket, Response response) {
+                OkHttpDelegate.this.onOpen(webSocket, response);
+            }
+
+            @Override
+            public void onMessage(WebSocket webSocket, String text) {
+                OkHttpDelegate.this.onData(text);
+            }
+
+            @Override
+            public void onClosing(WebSocket webSocket, int code, String reason) {
+                OkHttpDelegate.this.onClose(code, reason);
+            }
+
+            @Override
+            public void onFailure(WebSocket webSocket, Throwable failure, Response response) {
+                OkHttpDelegate.this.failMessages(failure);
+            }
+        }
+    }
+
+    public static class Factory extends ContainerLifeCycle implements ClientTransport.Factory {
+        private final OkHttpClient okHttpClient;
+
+        public Factory(OkHttpClient okHttpClient) {
+            this.okHttpClient = okHttpClient;
+            addBean(okHttpClient);
+        }
+
+        @Override
+        public ClientTransport newClientTransport(String url, Map<String, Object> options) {
+            ScheduledExecutorService scheduler = (ScheduledExecutorService)options.get(ClientTransport.SCHEDULER_OPTION);
+            return new OkHttpWebsocketTransport(url, options, scheduler, okHttpClient);
+        }
+    }
+}

--- a/cometd-java/cometd-java-websocket/pom.xml
+++ b/cometd-java/cometd-java-websocket/pom.xml
@@ -18,6 +18,7 @@
     <module>cometd-java-websocket-javax-server</module>
     <module>cometd-java-websocket-jetty-client</module>
     <module>cometd-java-websocket-jetty-server</module>
+      <module>cometd-java-websocket-okhttp-client</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Introduces an OkHttp-based transport. This is useful for environments that
for whatever reason do not have a javax.websocket client.

It comes with two caveats:
1. Message sending can not be made blocking with the current OkHttp APIs. Failures sending will asynchronously result in failure callbacks. A test has been changed to account for this.
2. There is no way to specify a max message size for the OkHttp buffer or for individual messages. A test has been skipped for OkHttp to account for this.

Signed-off-by: Nate Klein <klein.nathaniel@gmail.com>