### PR TITLE
Fix NullPointer in Seti.disassociate when user is not registered

### DIFF
--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Seti.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Seti.java
@@ -362,17 +362,22 @@ public class Seti extends AbstractLifeCycle implements Dumpable {
      * @see #associate(String, ServerSession)
      */
     public Set<ServerSession> disassociate(final String userId) {
-        final Set<LocalLocation> userLocations = new HashSet<>();
+        final Set<LocalLocation> localLocations = new HashSet<>();
+        final Set<ServerSession> removedUserSessions = new HashSet<>();
         synchronized (_uid2Location) {
-            for (Location location : _uid2Location.get(userId)) {
+            final Set<Location> userLocations = _uid2Location.get(userId);
+            if (userLocations == null) {
+                return removedUserSessions;
+            }
+
+            for (Location location : userLocations) {
                 if (location instanceof LocalLocation) {
-                    userLocations.add((LocalLocation)location);
+                    localLocations.add((LocalLocation)location);
                 }
             }
         }
 
-        final Set<ServerSession> removedUserSessions = new HashSet<>();
-        for (LocalLocation location : userLocations) {
+        for (LocalLocation location : localLocations) {
             final ServerSession session = location._session;
             boolean removed = disassociate(userId, session);
             if (removed) {

--- a/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/SetiTest.java
+++ b/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/SetiTest.java
@@ -1107,6 +1107,30 @@ public class SetiTest extends OortTest {
         Assert.assertEquals(0, ((ServerSessionImpl)session).getListeners().size());
     }
 
+    @Test
+    public void testDisassociateAllSessions() throws Exception {
+        Server server1 = startServer(0);
+        Oort oort1 = startOort(server1);
+
+        Seti seti1 = startSeti(oort1);
+
+        String user = "user";
+        LocalSession localSession = oort1.getBayeuxServer().newLocalSession(user);
+        localSession.handshake();
+        ServerSession session = localSession.getServerSession();
+
+        seti1.associate(user, session);
+        Set<ServerSession> removedSessions = seti1.disassociate(user);
+
+        Assert.assertEquals(1, removedSessions.size());
+        Assert.assertEquals(session, removedSessions.iterator().next());
+        Assert.assertEquals(0, ((ServerSessionImpl)session).getListeners().size());
+
+        // Doesn't throw an Exception when userId is not known
+        Set<ServerSession> removedUnknownSessions = seti1.disassociate("unknown-user");
+        Assert.assertEquals(0, removedUnknownSessions.size());
+    }
+
     private static class UserPresentListener implements Seti.PresenceListener {
         private final CountDownLatch latch;
 


### PR DESCRIPTION
`Seti.disassociate` is throwing a NullPointerException when user is not known.

P.S I have added the original implementation of this method and it took four years to discover it :) 