### PR TITLE
use the correct name for the WebSocketUpgradeFilter

### DIFF
--- a/cometd-java/cometd-java-benchmark/cometd-java-benchmark-client/pom.xml
+++ b/cometd-java/cometd-java-benchmark/cometd-java-benchmark-client/pom.xml
@@ -61,6 +61,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-javax-websocket-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.cometd.java</groupId>
       <artifactId>cometd-java-api-client</artifactId>
       <version>${project.version}</version>

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/WebAppTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/WebAppTest.java
@@ -129,7 +129,6 @@ public class WebAppTest {
         copyWebAppDependency(org.eclipse.jetty.websocket.client.WebSocketClient.class, webINF);
         copyWebAppDependency(org.eclipse.jetty.websocket.core.client.WebSocketCoreClient.class, webINF);
         copyWebAppDependency(org.eclipse.jetty.websocket.core.Configuration.class, webINF);
-        copyWebAppDependency(org.eclipse.jetty.websocket.util.InvalidSignatureException.class, webINF);
         // Application classes.
         Path testClasses = baseDir.resolve("target/test-classes/");
         String serviceClass = WebAppService.class.getName().replace('.', '/') + ".class";

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jetty-ws-web.xml
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jetty-ws-web.xml
@@ -21,13 +21,13 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>wsuf</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
     <filter-class>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>
-    <filter-name>wsuf</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
     <url-pattern>/cometd/*</url-pattern>
   </filter-mapping>
 

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jetty-ws-web.xml
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jetty-ws-web.xml
@@ -21,13 +21,13 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
-    <filter-class>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-class>
+    <filter-name>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-name>
+    <filter-class>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>
-    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-name>
     <url-pattern>/cometd/*</url-pattern>
   </filter-mapping>
 

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jsr-ws-web.xml
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jsr-ws-web.xml
@@ -21,13 +21,13 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>wsuf</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
     <filter-class>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>
-    <filter-name>wsuf</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
     <url-pattern>/cometd/*</url-pattern>
   </filter-mapping>
 

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jsr-ws-web.xml
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/resources/jsr-ws-web.xml
@@ -21,13 +21,13 @@
   </filter-mapping>
 
   <filter>
-    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
-    <filter-class>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-class>
+    <filter-name>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-name>
+    <filter-class>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-class>
     <async-supported>true</async-supported>
   </filter>
 
   <filter-mapping>
-    <filter-name>org.eclipse.jetty.websocket.util.server.WebSocketUpgradeFilter</filter-name>
+    <filter-name>org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter</filter-name>
     <url-pattern>/cometd/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
Use a specific name for the `WebSocketUpgradeFilter` so the implementation can detect that an upgrade filter has already been installed and does not create a new one.

Wait for https://github.com/eclipse/jetty.project/pull/5648 to be resolved before merging.