### PR TITLE
Handle UnknownHostException along with other network exceptions

### DIFF
--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-okhttp/src/main/java/org/cometd/client/websocket/okhttp/OkHttpWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-okhttp/src/main/java/org/cometd/client/websocket/okhttp/OkHttpWebSocketTransport.java
@@ -20,6 +20,7 @@ import java.net.ConnectException;
 import java.net.HttpCookie;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.net.URI;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.LinkedHashMap;
@@ -96,6 +97,7 @@ public class OkHttpWebSocketTransport extends AbstractWebSocketTransport {
                 | SocketTimeoutException
                 | TimeoutException
                 | UnresolvedAddressException
+                | UnknownHostException
                 | ProtocolException e) { // RealWebSocket#checkResponse throws ProtocolException for certain responses
             listener.onFailure(e, messages);
         } catch (InterruptedException e) {


### PR DESCRIPTION
This error can be transient, and we do not want to consider websockets unsupported
in these cases. So, handle UnknownHostException similar to ConnectException and other
network layer issues.

Signed-off-by: Nate Klein <nklein@palantir.com>