### PR TITLE
Handle UnknownHostException for all Websocket transports

### DIFF
--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-javax/src/main/java/org/cometd/client/websocket/javax/WebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-javax/src/main/java/org/cometd/client/websocket/javax/WebSocketTransport.java
@@ -21,6 +21,7 @@ import java.net.HttpCookie;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -99,7 +100,7 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
             Delegate delegate = connect(_webSocketContainer, config, uri);
             _webSocketConnected = true;
             return delegate;
-        } catch (ConnectException | SocketTimeoutException | UnresolvedAddressException x) {
+        } catch (ConnectException | SocketTimeoutException | UnresolvedAddressException | UnknownHostException x) {
             // Cannot connect, assume the server supports WebSocket until proved otherwise
             listener.onFailure(x, messages);
         } catch (Throwable x) {

--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
@@ -20,6 +20,7 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.HashMap;
 import java.util.List;
@@ -98,7 +99,7 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport implemen
             Delegate delegate = connect(_webSocketClient, request, uri);
             _webSocketConnected = true;
             return delegate;
-        } catch (ConnectException | SocketTimeoutException | UnresolvedAddressException x) {
+        } catch (ConnectException | SocketTimeoutException | UnresolvedAddressException | UnknownHostException x) {
             // Cannot connect, assume the server supports WebSocket until proved otherwise
             listener.onFailure(x, messages);
         } catch (UpgradeException x) {


### PR DESCRIPTION
Similar to handling in the okhttp transport, consider
UnknownHostException a non-fatal issue for whether the transport
supports websockets.

Signed-off-by: Nate Klein <nklein@palantir.com>