### PR TITLE
Fixes #1097 - Messages lost via WebSocket when browsers refresh.

### DIFF
--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -1389,7 +1389,9 @@ public class BayeuxServerImpl extends ContainerLifeCycle implements BayeuxServer
             reply.put(Message.SUPPORTED_CONNECTION_TYPES_FIELD, getAllowedTransports());
 
             Map<String, Object> adviceOut = session.takeAdvice(message.getServerTransport());
-            reply.put(Message.ADVICE_FIELD, adviceOut);
+            if (adviceOut != null) {
+                reply.put(Message.ADVICE_FIELD, adviceOut);
+            }
 
             promise.succeed(true);
         } else {

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
@@ -783,12 +783,13 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
         _transport = transport;
     }
 
-    public boolean updateServerEndPoint(Object endPoint) {
-        if (_endPoint == endPoint) {
+    public boolean updateServerEndPoint(Object newEndPoint) {
+        Object oldEndPoint = _endPoint;
+        if (oldEndPoint == newEndPoint) {
             return false;
         }
-        _endPoint = endPoint;
-        return true;
+        _endPoint = newEndPoint;
+        return oldEndPoint != null;
     }
 
     @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
@@ -64,6 +64,7 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
     private AbstractServerTransport.Scheduler _scheduler = new Scheduler.None(0);
     private ServerTransport _transport;
     private ServerTransport _advisedTransport;
+    private Object _endPoint;
     private State _state = State.NEW;
     private int _maxQueue = -1;
     private long _transientTimeout = -1;
@@ -780,6 +781,14 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
 
     public void setServerTransport(ServerTransport transport) {
         _transport = transport;
+    }
+
+    public boolean updateServerEndPoint(Object endPoint) {
+        if (_endPoint == endPoint) {
+            return false;
+        }
+        _endPoint = endPoint;
+        return true;
     }
 
     @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
@@ -789,7 +789,7 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
             return false;
         }
         _endPoint = newEndPoint;
-        return oldEndPoint != null;
+        return true;
     }
 
     @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -155,12 +155,16 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
             context.messages = messages;
             context.session = session;
             context.bayeuxContext = new HttpContext(context.request);
-            AsyncFoldLeft.run(messages, null, (result, item, loop) -> processMessage(context, (ServerMessageImpl)item, Promise.from(loop::proceed, loop::fail)), Promise.from(y -> {
-                flush(context, promise);
+            AsyncFoldLeft.run(messages, null, (result, item, loop) -> processMessage(context, (ServerMessageImpl)item, Promise.from(loop::proceed, loop::fail)), Promise.complete((r, x) -> {
+                if (x == null) {
+                    flush(context, promise);
+                } else {
+                    promise.fail(x);
+                }
                 if (batch) {
                     session.endBatch();
                 }
-            }, promise::fail));
+            }));
         }
     }
 

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/MessageDeliveryDuringHandshakeTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/MessageDeliveryDuringHandshakeTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.cometd.bayeux.Channel;
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.Promise;
@@ -79,25 +80,18 @@ public class MessageDeliveryDuringHandshakeTest extends AbstractClientServerTest
             }
         });
 
-        CountDownLatch messagesLatch = new CountDownLatch(1);
-        ServerChannel metaConnectChannel = bayeux.getChannel(Channel.META_CONNECT);
-        metaConnectChannel.addListener(new ServerChannel.MessageListener() {
-            @Override
-            public boolean onMessage(ServerSession from, ServerChannel channel, ServerMessage.Mutable message) {
-                // Check the queue when receiving the first /meta/connect.
-                if (((ServerSessionImpl)from).getQueue().isEmpty() == allowHandshakeMessages) {
-                    messagesLatch.countDown();
-                }
-                metaConnectChannel.removeListener(this);
-                return true;
-            }
-        });
-
         BlockingQueue<Message> messages = new LinkedBlockingQueue<>();
         ClientSessionChannel.MessageListener listener = (channel, message) -> messages.offer(message);
         client.getChannel(Channel.META_HANDSHAKE).addListener(listener);
         client.getChannel(channelName).addListener(listener);
         client.getChannel(Channel.META_CONNECT).addListener(listener);
+
+        CountDownLatch messagesLatch = new CountDownLatch(1);
+        client.getChannel(Channel.META_HANDSHAKE).addListener((ClientSessionChannel.MessageListener)(channel, message) -> {
+            ServerSessionImpl serverSession = (ServerSessionImpl)bayeux.getSession(client.getId());
+            if (serverSession.getQueue().isEmpty() == allowHandshakeMessages)
+                messagesLatch.countDown();
+        });
 
         client.handshake();
 
@@ -167,6 +161,112 @@ public class MessageDeliveryDuringHandshakeTest extends AbstractClientServerTest
         Message message = messages.poll(1, TimeUnit.SECONDS);
         Assertions.assertNotNull(message);
         Assertions.assertEquals(Channel.META_HANDSHAKE, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(channelName, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(Channel.META_CONNECT, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNull(message);
+
+        disconnectBayeuxClient(client);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testSecondHandshakeMessagesNotSentInHandshakeResponse(Transport transport) throws Exception {
+        startServer(transport);
+        BayeuxClient client = newBayeuxClient(transport);
+        testSecondHandshakeMessagesInHandshakeResponse(client, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testSecondHandshakeMessagesSentInHandshakeResponse(Transport transport) throws Exception {
+        Map<String, String> options = serverOptions(transport);
+        options.put(AbstractServerTransport.ALLOW_MESSAGE_DELIVERY_DURING_HANDSHAKE, String.valueOf(true));
+        startServer(transport, options);
+        BayeuxClient client = newBayeuxClient(transport);
+        testSecondHandshakeMessagesInHandshakeResponse(client, true);
+    }
+
+    private void testSecondHandshakeMessagesInHandshakeResponse(BayeuxClient client, boolean allowHandshakeMessages) throws Exception {
+        String channelName = "/test";
+        bayeux.addListener(new BayeuxServer.SessionListener() {
+            @Override
+            public void sessionAdded(ServerSession session, ServerMessage message) {
+                // Send messages during the handshake processing.
+                session.deliver(null, channelName, "data1", Promise.noop());
+                session.deliver(null, channelName, "data2", Promise.noop());
+            }
+        });
+
+        // Arrange to make the client send a second handshake.
+        AtomicInteger metaConnects = new AtomicInteger();
+        bayeux.getChannel(Channel.META_CONNECT).addListener(new ServerChannel.MessageListener() {
+            @Override
+            public boolean onMessage(ServerSession sender, ServerChannel channel, ServerMessage.Mutable message) {
+                if (metaConnects.incrementAndGet() == 2) {
+                    Map<String, Object> adviceIn = message.getAdvice(true);
+                    adviceIn.put(Message.TIMEOUT_FIELD, 0L);
+                }
+                return true;
+            }
+        });
+        bayeux.addExtension(new BayeuxServer.Extension() {
+            @Override
+            public boolean sendMeta(ServerSession to, ServerMessage.Mutable message) {
+                if (Channel.META_CONNECT.equals(message.getChannel())) {
+                    if (metaConnects.get() == 2) {
+                        message.setSuccessful(false);
+                        Map<String, Object> advice = message.getAdvice(true);
+                        advice.put(Message.RECONNECT_FIELD, Message.RECONNECT_HANDSHAKE_VALUE);
+                    }
+                }
+                return true;
+            }
+        });
+
+        BlockingQueue<Message> messages = new LinkedBlockingQueue<>();
+        ClientSessionChannel.MessageListener listener = (channel, message) -> messages.offer(message);
+        client.getChannel(Channel.META_HANDSHAKE).addListener(listener);
+        client.getChannel(Channel.META_CONNECT).addListener(listener);
+        client.getChannel(channelName).addListener(listener);
+
+        CountDownLatch messagesLatch = new CountDownLatch(2);
+        client.getChannel(Channel.META_HANDSHAKE).addListener((ClientSessionChannel.MessageListener)(channel, message) -> {
+            ServerSessionImpl serverSession = (ServerSessionImpl)bayeux.getSession(client.getId());
+            if (serverSession.getQueue().isEmpty() == allowHandshakeMessages)
+                messagesLatch.countDown();
+        });
+
+        client.handshake();
+
+        Assertions.assertTrue(messagesLatch.await(5, TimeUnit.SECONDS));
+
+        // Make sure that the messages arrive in the expected order.
+        Message message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(Channel.META_HANDSHAKE, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(channelName, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(channelName, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(Channel.META_CONNECT, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(Channel.META_CONNECT, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(Channel.META_HANDSHAKE, message.getChannel());
+        message = messages.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(message);
+        Assertions.assertEquals(channelName, message.getChannel());
         message = messages.poll(1, TimeUnit.SECONDS);
         Assertions.assertNotNull(message);
         Assertions.assertEquals(channelName, message.getChannel());


### PR DESCRIPTION
Now updating the Scheduler as soon as a new WebSocket connection is detected.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>