### PR TITLE
Bumps log4j to 2.15.0 to fix log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <!-- end::jetty-version[] -->
     <graalvm-version>21.3.0</graalvm-version>
     <slf4j-version>1.7.32</slf4j-version>
-    <log4j2-version>2.14.1</log4j2-version>
+    <log4j2-version>2.15.0</log4j2-version>
     <spring-version>5.3.13</spring-version>
     <spring-boot-version>2.6.1</spring-boot-version>
     <jackson-version>2.13.0</jackson-version>


### PR DESCRIPTION
Hello,

I've confirmed there are reachable code paths to trigger the latest log4j vulnerability. I didn't find a contact for security but I could share the details privately. 