### PR TITLE
Fixes #1180 - Wrong usage of "this" in cometd.js#_copyContext().

### DIFF
--- a/cometd-javascript/common/src/main/webapp/js/cometd/cometd.js
+++ b/cometd-javascript/common/src/main/webapp/js/cometd/cometd.js
@@ -659,7 +659,7 @@
             } catch (e) {
                 // May happen if XHR is wrapped by Object.seal(),
                 // Object.freeze(), or Object.preventExtensions().
-                this._debug('Could not copy transport context into XHR', e);
+                _self._debug('Could not copy transport context into XHR', e);
             }
         }
 


### PR DESCRIPTION
Thanks to @chasd00 for spotting the issue.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>