### PR TITLE
Fixes #1189 - Oort cluster may drop messages.

### DIFF
--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Oort.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Oort.java
@@ -731,7 +731,7 @@ public class Oort extends ContainerLifeCycle {
     private class AllChannelsFilter implements BayeuxServer.SubscriptionListener, ServerSession.MessageListener {
         @Override
         public void subscribed(ServerSession session, ServerChannel channel, ServerMessage message) {
-            if ("/**".equals(channel.getId()) && !session.isLocalSession()) {
+            if ("/**".equals(channel.getId()) && !session.isLocalSession() && !isOort(session)) {
                 session.addListener(this);
             }
         }

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortComet.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/OortComet.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
+import org.cometd.bayeux.ChannelId;
 import org.cometd.bayeux.client.ClientSession;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.client.BayeuxClient;
@@ -60,9 +61,12 @@ public class OortComet extends BayeuxClient {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Republishing message {} from {}", message, _cometURL);
                 }
-                // BayeuxServer may sweep channels, so calling bayeux.getChannel(...)
-                // may return null, and therefore we use the client to send the message.
-                _oort.getOortSession().getChannel(message.getChannel()).publish(message);
+                // Applications may observe /**, but we only want to republish broadcast messages.
+                if (ChannelId.isBroadcast(message.getChannel())) {
+                    // BayeuxServer may sweep channels, so calling bayeux.getChannel(...)
+                    // may return null, and therefore we use the client to send the message.
+                    _oort.getOortSession().getChannel(message.getChannel()).publish(message);
+                }
             };
 
             ClientSessionChannel.MessageListener existing = _subscriptions.putIfAbsent(channel, listener);

--- a/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Seti.java
+++ b/cometd-java/cometd-java-oort/src/main/java/org/cometd/oort/Seti.java
@@ -1078,7 +1078,7 @@ public class Seti extends AbstractLifeCycle implements Dumpable {
     private class AllChannelsFilter implements BayeuxServer.SubscriptionListener, ServerSession.MessageListener {
         @Override
         public void subscribed(ServerSession session, ServerChannel channel, ServerMessage message) {
-            if ("/**".equals(channel.getId()) && !session.isLocalSession()) {
+            if ("/**".equals(channel.getId()) && !session.isLocalSession() && !getOort().isOort(session)) {
                 session.addListener(this);
             }
         }

--- a/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/SetiTest.java
+++ b/cometd-java/cometd-java-oort/src/test/java/org/cometd/oort/SetiTest.java
@@ -139,6 +139,65 @@ public class SetiTest extends OortTest {
 
     @ParameterizedTest
     @MethodSource("transports")
+    public void testAssociateWithAllChannelsSubscription(String serverTransport) throws Exception {
+        Server server1 = startServer(serverTransport, 0);
+        Oort oort1 = startOort(server1);
+        Server server2 = startServer(serverTransport, 0);
+        Oort oort2 = startOort(server2);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        oort2.addCometListener(new CometJoinedListener(latch));
+        OortComet oortComet12 = oort1.observeComet(oort2.getURL());
+        Assertions.assertTrue(oortComet12.waitFor(5000, BayeuxClient.State.CONNECTED));
+        Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
+        OortComet oortComet21 = oort2.findComet(oort1.getURL());
+        Assertions.assertTrue(oortComet21.waitFor(5000, BayeuxClient.State.CONNECTED));
+
+        Seti seti1 = startSeti(oort1);
+        Seti seti2 = startSeti(oort2);
+
+        // Subscribe to /**, which is treated specially in Oort and Seti.
+        oort1.observeChannel("/**");
+        oort2.observeChannel("/**");
+        // Wait a while to be sure to be subscribed.
+        Thread.sleep(1000);
+
+        CountDownLatch presenceLatch = new CountDownLatch(4);
+        UserPresentListener presenceListener = new UserPresentListener(presenceLatch);
+        seti1.addPresenceListener(presenceListener);
+        seti2.addPresenceListener(presenceListener);
+
+        new SetiService(seti1);
+        new SetiService(seti2);
+
+        BayeuxClient client1 = startClient(oort1, null);
+        Assertions.assertTrue(client1.waitFor(5000, BayeuxClient.State.CONNECTED));
+        BayeuxClient client2 = startClient(oort2, null);
+        Assertions.assertTrue(client2.waitFor(5000, BayeuxClient.State.CONNECTED));
+
+        LatchListener publishLatch = new LatchListener();
+        String loginChannelName = "/service/login";
+
+        Map<String, Object> login1 = new HashMap<>();
+        login1.put("user", "user1");
+        ClientSessionChannel loginChannel1 = client1.getChannel(loginChannelName);
+        loginChannel1.addListener(publishLatch);
+        loginChannel1.publish(login1);
+        Assertions.assertTrue(publishLatch.await(5, TimeUnit.SECONDS));
+
+        publishLatch.reset(1);
+        Map<String, Object> login2 = new HashMap<>();
+        login2.put("user", "user2");
+        ClientSessionChannel loginChannel2 = client2.getChannel(loginChannelName);
+        loginChannel2.addListener(publishLatch);
+        loginChannel2.publish(login2);
+        Assertions.assertTrue(publishLatch.await(5, TimeUnit.SECONDS));
+
+        Assertions.assertTrue(presenceLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
     public void testDisassociate(String serverTransport) throws Exception {
         Server server1 = startServer(serverTransport, 0);
         Oort oort1 = startOort(server1);


### PR DESCRIPTION
In case of subscription to /**, now also testing whether the session
is an Oort session, and if so allowing the message.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>