### PR TITLE
Fixes #1197 - Support permessage-deflate in benchmarks

### DIFF
--- a/cometd-java/cometd-java-benchmark/cometd-java-benchmark-client/src/main/java/org/cometd/benchmark/client/CometDLoadClient.java
+++ b/cometd-java/cometd-java-benchmark/cometd-java-benchmark-client/src/main/java/org/cometd/benchmark/client/CometDLoadClient.java
@@ -117,11 +117,12 @@ public class CometDLoadClient implements MeasureConverter {
     private boolean interactive = true;
     private String host = "localhost";
     private int port = 8080;
-    private ClientTransportType transport = ClientTransportType.LONG_POLLING;
-    private boolean http2 = false;
     private boolean tls = false;
     private int selectors = 1;
     private int maxThreads = 256;
+    private ClientTransportType transport = ClientTransportType.LONG_POLLING;
+    private boolean http2 = false;
+    private boolean perMessageDeflate = false;
     private String context = Config.CONTEXT_PATH;
     private String channel = "/a";
     private int rooms = 100;
@@ -150,16 +151,18 @@ public class CometDLoadClient implements MeasureConverter {
                 client.host = arg.substring("--host=".length());
             } else if (arg.startsWith("--port=")) {
                 client.port = Integer.parseInt(arg.substring("--port=".length()));
-            } else if (arg.startsWith("--transport=")) {
-                client.transport = ClientTransportType.valueOf(arg.substring("--transport=".length()));
-            } else if (arg.equals("--http2")) {
-                client.http2 = true;
             } else if (arg.equals("--tls")) {
                 client.tls = true;
             } else if (arg.startsWith("--selectors=")) {
                 client.selectors = Integer.parseInt(arg.substring("--selectors=".length()));
             } else if (arg.startsWith("--maxThreads=")) {
                 client.maxThreads = Integer.parseInt(arg.substring("--maxThreads=".length()));
+            } else if (arg.startsWith("--transport=")) {
+                client.transport = ClientTransportType.valueOf(arg.substring("--transport=".length()));
+            } else if (arg.equals("--http2")) {
+                client.http2 = true;
+            } else if (arg.equals("--permessage-deflate")) {
+                client.perMessageDeflate = true;
             } else if (arg.startsWith("--context=")) {
                 client.context = arg.substring("--context=".length());
             } else if (arg.startsWith("--channel=")) {
@@ -273,6 +276,21 @@ public class CometDLoadClient implements MeasureConverter {
         } else {
             http2 = false;
         }
+
+        boolean perMessageDeflate = this.perMessageDeflate;
+        if (transport == ClientTransportType.JETTY_WEBSOCKET || transport == ClientTransportType.JSR_WEBSOCKET) {
+            if (interactive) {
+                System.err.printf("enable permessage-deflate extension [%b]: ", perMessageDeflate);
+                String value = console.readLine().trim();
+                if (value.length() == 0) {
+                    value = String.valueOf(perMessageDeflate);
+                }
+                perMessageDeflate = Boolean.parseBoolean(value);
+            }
+        } else {
+            perMessageDeflate = false;
+        }
+        this.perMessageDeflate = perMessageDeflate;
 
         String contextPath = this.context;
         if (interactive) {
@@ -663,6 +681,7 @@ public class CometDLoadClient implements MeasureConverter {
                 // Differently from HTTP where the idle timeout is adjusted if it is a /meta/connect
                 // for WebSocket we need an idle timeout that is longer than the /meta/connect timeout.
                 options.put(WebSocketTransport.IDLE_TIMEOUT_OPTION, Config.META_CONNECT_TIMEOUT + httpClient.getIdleTimeout());
+                options.put(WebSocketTransport.PERMESSAGE_DEFLATE_OPTION, perMessageDeflate);
                 return new WebSocketTransport(options, scheduler, webSocketContainer);
             }
             case JETTY_WEBSOCKET: {
@@ -673,6 +692,7 @@ public class CometDLoadClient implements MeasureConverter {
                 // Differently from HTTP where the idle timeout is adjusted if it is a /meta/connect
                 // for WebSocket we need an idle timeout that is longer than the /meta/connect timeout.
                 options.put(JettyWebSocketTransport.IDLE_TIMEOUT_OPTION, Config.META_CONNECT_TIMEOUT + httpClient.getIdleTimeout());
+                options.put(WebSocketTransport.PERMESSAGE_DEFLATE_OPTION, perMessageDeflate);
                 return new JettyWebSocketTransport(options, scheduler, webSocketClient);
             }
             default: {

--- a/cometd-java/cometd-java-benchmark/cometd-java-benchmark-server/src/main/java/org/cometd/benchmark/server/CometDLoadServer.java
+++ b/cometd-java/cometd-java-benchmark/cometd-java-benchmark-server/src/main/java/org/cometd/benchmark/server/CometDLoadServer.java
@@ -54,6 +54,7 @@ import org.cometd.server.ext.AcknowledgedMessagesExtension;
 import org.cometd.server.http.AsyncJSONTransport;
 import org.cometd.server.http.JSONTransport;
 import org.cometd.server.websocket.common.AbstractWebSocketEndPoint;
+import org.cometd.server.websocket.common.AbstractWebSocketTransport;
 import org.cometd.server.websocket.javax.WebSocketTransport;
 import org.cometd.server.websocket.jetty.JettyWebSocketTransport;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
@@ -91,6 +92,7 @@ public class CometDLoadServer {
     private int selectors = Runtime.getRuntime().availableProcessors();
     private int maxThreads = 256;
     private String transports = "jsrws,asynchttp";
+    private boolean perMessageDeflate = false;
     private boolean statistics = true;
     private boolean latencies = true;
     private boolean longRequests = false;
@@ -117,6 +119,8 @@ public class CometDLoadServer {
                 server.maxThreads = Integer.parseInt(arg.substring("--maxThreads=".length()));
             } else if (arg.startsWith("--transports=")) {
                 server.transports = arg.substring("--transports=".length());
+            } else if (arg.equals("--permessage-deflate")) {
+                server.perMessageDeflate = true;
             } else if (arg.equals("--statistics")) {
                 server.statistics = true;
             } else if (arg.equals("--latencies")) {
@@ -186,24 +190,33 @@ public class CometDLoadServer {
             transports = value;
         }
         for (String token : transports.split(",")) {
-            switch (token.trim()) {
-                case "jsrws":
-                    bayeuxServer.addTransport(new WebSocketTransport(bayeuxServer) {
+            String transport = token.trim();
+            switch (transport) {
+                case "jsrws": {
+                    boolean perMessageDeflate = readPerMessageDeflate(transport, console);
+                    WebSocketTransport serverTransport = new WebSocketTransport(bayeuxServer) {
                         @Override
                         protected void writeComplete(AbstractWebSocketEndPoint.Context context, List<ServerMessage> messages) {
                             messageLatencyExtension.complete(messages);
                         }
-                    });
+                    };
+                    serverTransport.setOption(AbstractWebSocketTransport.ENABLE_EXTENSION_PREFIX_OPTION + "permessage-deflate", perMessageDeflate);
+                    bayeuxServer.addTransport(serverTransport);
                     break;
-                case "jettyws":
-                    bayeuxServer.addTransport(new JettyWebSocketTransport(bayeuxServer) {
+                }
+                case "jettyws": {
+                    boolean perMessageDeflate = readPerMessageDeflate(transport, console);
+                    JettyWebSocketTransport serverTransport = new JettyWebSocketTransport(bayeuxServer) {
                         @Override
                         protected void writeComplete(AbstractWebSocketEndPoint.Context context, List<ServerMessage> messages) {
                             messageLatencyExtension.complete(messages);
                         }
-                    });
+                    };
+                    serverTransport.setOption(AbstractWebSocketTransport.ENABLE_EXTENSION_PREFIX_OPTION + "permessage-deflate", perMessageDeflate);
+                    bayeuxServer.addTransport(serverTransport);
                     break;
-                case "http":
+                }
+                case "http": {
                     bayeuxServer.addTransport(new JSONTransport(bayeuxServer) {
                         @Override
                         protected void writeComplete(Context context, List<ServerMessage> messages) {
@@ -211,7 +224,8 @@ public class CometDLoadServer {
                         }
                     });
                     break;
-                case "asynchttp":
+                }
+                case "asynchttp": {
                     bayeuxServer.addTransport(new AsyncJSONTransport(bayeuxServer) {
                         @Override
                         protected void writeComplete(Context context, List<ServerMessage> messages) {
@@ -219,8 +233,10 @@ public class CometDLoadServer {
                         }
                     });
                     break;
-                default:
+                }
+                default: {
                     throw new IllegalArgumentException("Invalid transport: " + token);
+                }
             }
         }
 
@@ -346,6 +362,19 @@ public class CometDLoadServer {
         server.start();
 
         new StatisticsService(this);
+    }
+
+    private boolean readPerMessageDeflate(String transport, BufferedReader console) throws IOException {
+        boolean perMessageDeflate = this.perMessageDeflate;
+        if (interactive) {
+            System.err.printf("enable %s permessage-deflate extension [%b]: ", transport, perMessageDeflate);
+            String value = console.readLine().trim();
+            if (value.length() == 0) {
+                value = String.valueOf(perMessageDeflate);
+            }
+            perMessageDeflate = Boolean.parseBoolean(value);
+        }
+        return perMessageDeflate;
     }
 
     public static class StatisticsService extends AbstractService {

--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-common/src/main/java/org/cometd/client/websocket/common/AbstractWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-common/src/main/java/org/cometd/client/websocket/common/AbstractWebSocketTransport.java
@@ -43,6 +43,7 @@ public abstract class AbstractWebSocketTransport extends HttpClientTransport imp
     public static final String PREFIX = "ws";
     public static final String NAME = "websocket";
     public static final String PROTOCOL_OPTION = "protocol";
+    public static final String PERMESSAGE_DEFLATE_OPTION = "permessageDeflate";
     public static final String CONNECT_TIMEOUT_OPTION = "connectTimeout";
     public static final String IDLE_TIMEOUT_OPTION = "idleTimeout";
     public static final String STICKY_RECONNECT_OPTION = "stickyReconnect";
@@ -54,6 +55,7 @@ public abstract class AbstractWebSocketTransport extends HttpClientTransport imp
     private final Object _lock = this;
     private boolean _open;
     private String _protocol;
+    private boolean _perMessageDeflate;
     private long _connectTimeout;
     private long _idleTimeout;
     private boolean _stickyReconnect;
@@ -80,6 +82,7 @@ public abstract class AbstractWebSocketTransport extends HttpClientTransport imp
     public void init() {
         super.init();
         _protocol = getOption(PROTOCOL_OPTION, _protocol);
+        _perMessageDeflate = getOption(PERMESSAGE_DEFLATE_OPTION, false);
         setMaxNetworkDelay(15000L);
         _connectTimeout = 30000L;
         _idleTimeout = 60000L;
@@ -105,6 +108,10 @@ public abstract class AbstractWebSocketTransport extends HttpClientTransport imp
 
     public String getProtocol() {
         return _protocol;
+    }
+
+    public boolean isPerMessageDeflateEnabled() {
+        return _perMessageDeflate;
     }
 
     public long getIdleTimeout() {

--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
@@ -96,6 +96,9 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport implemen
             if (protocol != null) {
                 request.setSubProtocols(protocol);
             }
+            if (isPerMessageDeflateEnabled()) {
+                request.addExtensions("permessage-deflate");
+            }
             Delegate delegate = connect(_webSocketClient, request, uri);
             _webSocketConnected = true;
             return delegate;

--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-okhttp/src/main/java/org/cometd/client/websocket/okhttp/OkHttpWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-okhttp/src/main/java/org/cometd/client/websocket/okhttp/OkHttpWebSocketTransport.java
@@ -46,8 +46,9 @@ import org.slf4j.LoggerFactory;
 
 public class OkHttpWebSocketTransport extends AbstractWebSocketTransport {
     private static final Logger LOGGER = LoggerFactory.getLogger(OkHttpWebSocketTransport.class);
-    private static final String SEC_WEB_SOCKET_PROTOCOL_HEADER = "Sec-WebSocket-Protocol";
-    private static final String SEC_WEB_SOCKET_ACCEPT_HEADER = "Sec-WebSocket-Accept";
+    private static final String SEC_WEBSOCKET_EXTENSIONS_HEADER = "Sec-WebSocket-Extensions";
+    private static final String SEC_WEBSOCKET_PROTOCOL_HEADER = "Sec-WebSocket-Protocol";
+    private static final String SEC_WEBSOCKET_ACCEPT_HEADER = "Sec-WebSocket-Accept";
 
     private final OkHttpClient okHttpClient;
     private boolean webSocketSupported;
@@ -124,7 +125,10 @@ public class OkHttpWebSocketTransport extends AbstractWebSocketTransport {
         upgradeRequest.url(uri);
         String protocol = getProtocol();
         if (protocol != null && !protocol.isEmpty()) {
-            upgradeRequest.header(SEC_WEB_SOCKET_PROTOCOL_HEADER, protocol);
+            upgradeRequest.header(SEC_WEBSOCKET_PROTOCOL_HEADER, protocol);
+        }
+        if (isPerMessageDeflateEnabled()) {
+            upgradeRequest.addHeader(SEC_WEBSOCKET_EXTENSIONS_HEADER, "permessage-deflate");
         }
         List<HttpCookie> cookies = getCookies(URI.create(uri));
         for (HttpCookie cookie : cookies) {
@@ -134,7 +138,7 @@ public class OkHttpWebSocketTransport extends AbstractWebSocketTransport {
     }
 
     protected void onHandshakeResponse(Response response) {
-        webSocketSupported = response.header(SEC_WEB_SOCKET_ACCEPT_HEADER) != null;
+        webSocketSupported = response.header(SEC_WEBSOCKET_ACCEPT_HEADER) != null;
         storeCookies(URI.create(getURL()), headersToMap(response.headers()));
     }
 


### PR DESCRIPTION
Addes support in client transports and in both the client and server benchmarks classes.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>