### PR TITLE
use default jenkins container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,18 +21,16 @@ pipeline {
           stage('Build CometD') {
             agent { node { label 'linux' } }
             steps {
-              container('jetty-build') {
-                timeout(time: 1, unit: 'HOURS') {
-                  mavenBuild("${env.JDK}", "clean install", [[parserName: 'Maven'], [parserName: 'Java']])
-                  // Collect the JaCoCo execution results.
-                  jacoco exclusionPattern: '**/org/webtide/**,**/org/cometd/benchmark/**,**/org/cometd/examples/**',
-                          execPattern: '**/target/jacoco.exec',
-                          classPattern: '**/target/classes',
-                          sourcePattern: '**/src/main/java'
-                }
-                timeout(time: 15, unit: 'MINUTES') {
-                  mavenBuild("${env.JDK}", "javadoc:javadoc", null)
-                }
+              timeout(time: 1, unit: 'HOURS') {
+                mavenBuild("${env.JDK}", "clean install", [[parserName: 'Maven'], [parserName: 'Java']])
+                // Collect the JaCoCo execution results.
+                jacoco exclusionPattern: '**/org/webtide/**,**/org/cometd/benchmark/**,**/org/cometd/examples/**',
+                        execPattern: '**/target/jacoco.exec',
+                        classPattern: '**/target/classes',
+                        sourcePattern: '**/src/main/java'
+              }
+              timeout(time: 15, unit: 'MINUTES') {
+                mavenBuild("${env.JDK}", "javadoc:javadoc", null)
               }
             }
           }


### PR DESCRIPTION
basically having to start 2 images (e.g container)  (one jnlp for Jenkinns and one for the build) is using too much resources and can have some performance impact (as the default in jnlp the container for build need to maintain some extra connection which waste resources)
So I have build a Docker image which contains all the tools for Jenkins and our build. 