### PR TITLE
Reviewed JSON APIs.

### DIFF
--- a/cometd-java/cometd-java-client/cometd-java-client-common/src/main/java/org/cometd/client/transport/ClientTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-common/src/main/java/org/cometd/client/transport/ClientTransport.java
@@ -16,7 +16,6 @@
 package org.cometd.client.transport;
 
 import java.text.ParseException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -151,7 +150,7 @@ public abstract class ClientTransport extends AbstractTransport {
     public abstract void send(TransportListener listener, List<Message.Mutable> messages);
 
     protected List<Message.Mutable> parseMessages(String content) throws ParseException {
-        return new ArrayList<>(List.of(jsonContext.parse(content)));
+        return jsonContext.parse(content);
     }
 
     protected String generateJSON(List<Message.Mutable> messages) {

--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/JSONContextTest.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/JSONContextTest.java
@@ -15,6 +15,7 @@
  */
 package org.cometd.client.http;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -82,8 +83,8 @@ public class JSONContextTest extends ClientServerTest {
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
 
         for (int i = 0; i < bytes.length; ++i) {
-            clientParser.parse(bytes, i, 1);
-            serverParser.parse(bytes, i, 1);
+            clientParser.parse(ByteBuffer.wrap(bytes, i, 1));
+            serverParser.parse(ByteBuffer.wrap(bytes, i, 1));
         }
         List<Message.Mutable> clientMessages = clientParser.complete();
         List<ServerMessage.Mutable> serverMessages = serverParser.complete();

--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/MultipleClientSessionsTest.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/MultipleClientSessionsTest.java
@@ -334,9 +334,9 @@ public class MultipleClientSessionsTest extends ClientServerTest {
         Assertions.assertEquals(1, cookies.size());
         HttpCookie browserCookie = cookies.get(0);
         Assertions.assertEquals("BAYEUX_BROWSER", browserCookie.getName());
-        Message.Mutable[] messages = parser.parse(handshake.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        String clientId = messages[0].getClientId();
+        List<Message.Mutable> messages = parser.parse(handshake.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        String clientId = messages.get(0).getClientId();
 
         String connectContent1 = "[{" +
                 "\"id\":\"2\"," +
@@ -408,8 +408,8 @@ public class MultipleClientSessionsTest extends ClientServerTest {
                 .send();
         Assertions.assertEquals(200, connect4.getStatus());
         messages = parser.parse(connect4.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message.Mutable message = messages[0];
+        Assertions.assertEquals(1, messages.size());
+        Message.Mutable message = messages.get(0);
         Map<String, Object> advice = message.getAdvice(true);
         Assertions.assertFalse(advice.containsKey("multiple-clients"));
     }

--- a/cometd-java/cometd-java-common/src/main/java/org/cometd/common/BufferingJSONAsyncParser.java
+++ b/cometd-java/cometd-java-common/src/main/java/org/cometd/common/BufferingJSONAsyncParser.java
@@ -17,7 +17,7 @@ package org.cometd.common;
 
 import java.nio.ByteBuffer;
 import java.text.ParseException;
-import java.util.List;
+
 import org.cometd.bayeux.Message;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 
@@ -36,11 +36,6 @@ public class BufferingJSONAsyncParser implements JSONContext.AsyncParser {
     }
 
     @Override
-    public void parse(byte[] bytes, int offset, int length) {
-        buffer.append(bytes, offset, length);
-    }
-
-    @Override
     public void parse(ByteBuffer byteBuffer) {
         buffer.append(byteBuffer);
     }
@@ -51,8 +46,7 @@ public class BufferingJSONAsyncParser implements JSONContext.AsyncParser {
         try {
             String json = buffer.toString();
             buffer.reset();
-            Message.Mutable[] result = jsonContext.parse(json);
-            return (R)List.of(result);
+            return (R)jsonContext.parse(json);
         } catch (ParseException x) {
             throw new IllegalArgumentException(x);
         }

--- a/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JSONContext.java
+++ b/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JSONContext.java
@@ -29,22 +29,13 @@ import org.cometd.bayeux.Message;
  */
 public interface JSONContext<T extends Message.Mutable> {
     /**
-     * <p>Parses an array of messages from the given reader.</p>
-     *
-     * @param reader the reader to parse from
-     * @return an array of messages
-     * @throws ParseException in case of parsing errors
-     */
-    public T[] parse(Reader reader) throws ParseException;
-
-    /**
      * <p>Parses an array of messages from the given string.</p>
      *
      * @param json the JSON string to parse from
      * @return an array of messages
      * @throws ParseException in case of parsing errors
      */
-    public T[] parse(String json) throws ParseException;
+    public List<T> parse(String json) throws ParseException;
 
     /**
      * @return a new {@link AsyncParser} instance, or null if non-blocking parsing is not supported
@@ -60,14 +51,6 @@ public interface JSONContext<T extends Message.Mutable> {
      * @return the JSON string for the message
      */
     public String generate(T message);
-
-    /**
-     * <p>Converts a list of messages to a JSON string.</p>
-     *
-     * @param messages the list of messages to stringify
-     * @return the JSON string for the messages
-     */
-    public String generate(List<T> messages);
 
     /**
      * @return a synchronous JSON parser to parse any JSON string
@@ -105,15 +88,6 @@ public interface JSONContext<T extends Message.Mutable> {
      * A non-blocking JSON parser.
      */
     public interface AsyncParser {
-        /**
-         * @param bytes  the bytes chunk to parse
-         * @param offset the offset to start parsing from
-         * @param length the number of bytes to parse
-         */
-        public default void parse(byte[] bytes, int offset, int length) {
-            parse(ByteBuffer.wrap(bytes, offset, length));
-        }
-
         /**
          * @param buffer the buffer chunk to parse
          */

--- a/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JacksonJSONContext.java
+++ b/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JacksonJSONContext.java
@@ -118,7 +118,9 @@ public abstract class JacksonJSONContext<M extends Message.Mutable, I extends M>
                     parseInput();
                 } else if (input instanceof ByteArrayFeeder feeder) {
                     if (buffer.hasArray()) {
-                        feeder.feedInput(buffer.array(), buffer.arrayOffset(), buffer.remaining());
+                        int startIndex = buffer.arrayOffset() + buffer.position();
+                        int endIndex = startIndex + buffer.remaining();
+                        feeder.feedInput(buffer.array(), startIndex, endIndex);
                     } else {
                         byte[] bytes = new byte[buffer.remaining()];
                         buffer.get(bytes);

--- a/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JacksonJSONContextClient.java
+++ b/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JacksonJSONContextClient.java
@@ -19,7 +19,7 @@ import org.cometd.bayeux.Message;
 
 public class JacksonJSONContextClient extends JacksonJSONContext<Message.Mutable, HashMapMessage> implements JSONContext.Client {
     @Override
-    protected Class<HashMapMessage[]> rootArrayClass() {
-        return HashMapMessage[].class;
+    protected Class<HashMapMessage> messageClass() {
+        return HashMapMessage.class;
     }
 }

--- a/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JettyJSONContextClient.java
+++ b/cometd-java/cometd-java-common/src/main/java/org/cometd/common/JettyJSONContextClient.java
@@ -19,12 +19,7 @@ import org.cometd.bayeux.Message;
 
 public class JettyJSONContextClient extends JettyJSONContext<Message.Mutable> implements JSONContext.Client {
     @Override
-    protected Message.Mutable newRoot() {
+    protected Message.Mutable newMessage() {
         return new HashMapMessage();
-    }
-
-    @Override
-    protected Message.Mutable[] newRootArray(int size) {
-        return new Message.Mutable[size];
     }
 }

--- a/cometd-java/cometd-java-common/src/test/java/org/cometd/common/JettyJacksonComparisonTest.java
+++ b/cometd-java/cometd-java-common/src/test/java/org/cometd/common/JettyJacksonComparisonTest.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import org.cometd.bayeux.Message;
-import org.cometd.bayeux.Message.Mutable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -34,7 +34,7 @@ public class JettyJacksonComparisonTest {
     public interface JSONProvider {
         String getName();
 
-        Message.Mutable[] parse(String json) throws Exception;
+        List<Message.Mutable> parse(String json) throws Exception;
 
         String generate(Message.Mutable message) throws Exception;
     }
@@ -48,7 +48,7 @@ public class JettyJacksonComparisonTest {
         }
 
         @Override
-        public org.cometd.bayeux.Message.Mutable[] parse(String json) throws Exception {
+        public List<Message.Mutable> parse(String json) throws Exception {
             return jacksonContextClient.parse(json);
         }
 
@@ -67,7 +67,7 @@ public class JettyJacksonComparisonTest {
         }
 
         @Override
-        public Mutable[] parse(String json) throws Exception {
+        public List<Message.Mutable> parse(String json) throws Exception {
             return jettyJSONContextClient.parse(json);
         }
 

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -17,6 +17,7 @@ package org.cometd.server;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.cometd.bayeux.Promise;
@@ -168,7 +169,7 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
         return _jsonContext;
     }
 
-    public ServerMessage.Mutable[] parseMessages(String json) throws ParseException {
+    public List<ServerMessage.Mutable> parseMessages(String json) throws ParseException {
         return _jsonContext.parse(json);
     }
 

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/JacksonJSONContextServer.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/JacksonJSONContextServer.java
@@ -20,8 +20,8 @@ import org.cometd.common.JacksonJSONContext;
 
 public class JacksonJSONContextServer extends JacksonJSONContext<ServerMessage.Mutable, ServerMessageImpl> implements JSONContextServer {
     @Override
-    protected Class<ServerMessageImpl[]> rootArrayClass() {
-        return ServerMessageImpl[].class;
+    protected Class<ServerMessageImpl> messageClass() {
+        return ServerMessageImpl.class;
     }
 
     @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/JettyJSONContextServer.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/JettyJSONContextServer.java
@@ -16,19 +16,15 @@
 package org.cometd.server;
 
 import java.util.List;
+
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.common.JettyJSONContext;
 import org.eclipse.jetty.util.ajax.AsyncJSON;
 
 public class JettyJSONContextServer extends JettyJSONContext<ServerMessage.Mutable> implements JSONContextServer {
     @Override
-    protected ServerMessage.Mutable newRoot() {
+    protected ServerMessage.Mutable newMessage() {
         return new ServerMessageImpl();
-    }
-
-    @Override
-    protected ServerMessage.Mutable[] newRootArray(int size) {
-        return new ServerMessage.Mutable[size];
     }
 
     @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/JSONPHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/JSONPHttpTransport.java
@@ -92,17 +92,17 @@ public class JSONPHttpTransport extends AbstractHttpTransport {
 
             List<ServerMessage.Mutable> messages;
             if (requestParameters.length == 1) {
-                ServerMessage.Mutable[] parsed = parseMessages(requestParameters[0]);
-                messages = parsed == null ? List.of() : List.of(parsed);
+                List<ServerMessage.Mutable> parsed = parseMessages(requestParameters[0]);
+                messages = parsed == null ? List.of() : parsed;
             } else {
                 messages = new ArrayList<>();
                 for (String batch : requestParameters) {
                     if (batch == null) {
                         continue;
                     }
-                    ServerMessage.Mutable[] parsed = parseMessages(batch);
+                    List<ServerMessage.Mutable> parsed = parseMessages(batch);
                     if (parsed != null) {
-                        messages.addAll(List.of(parsed));
+                        messages.addAll(parsed);
                     }
                 }
             }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/test/java/org/cometd/server/ServerMessageImplTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/test/java/org/cometd/server/ServerMessageImplTest.java
@@ -19,7 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.List;
 import java.util.Map;
+
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.server.ServerMessage;
 import org.junit.jupiter.api.Assertions;
@@ -53,8 +55,8 @@ public class ServerMessageImplTest {
                 "}";
 
         JSONContextServer jsonContext = new JettyJSONContextServer();
-        ServerMessage.Mutable[] messages = jsonContext.parse(originalJSON);
-        ServerMessageImpl message = (ServerMessageImpl)messages[0];
+        List<ServerMessage.Mutable> messages = jsonContext.parse(originalJSON);
+        ServerMessageImpl message = (ServerMessageImpl)messages.get(0);
 
         String json = jsonContext.generate(message);
         Assertions.assertTrue(json.contains("\"ext\":{\"extName\":\"extValue\"}"));
@@ -186,8 +188,8 @@ public class ServerMessageImplTest {
                 "}";
 
         JSONContextServer jsonContext = new JettyJSONContextServer();
-        ServerMessage.Mutable[] messages = jsonContext.parse(originalJSON);
-        ServerMessageImpl message = (ServerMessageImpl)messages[0];
+        List<ServerMessage.Mutable> messages = jsonContext.parse(originalJSON);
+        ServerMessageImpl message = (ServerMessageImpl)messages.get(0);
         Map<String, Object> data = message.getDataAsMap();
         Assertions.assertNull(data.get("nullData"));
         Assertions.assertTrue(data.containsKey("nullData"));

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
@@ -126,7 +126,7 @@ class JakartaCometDRequest implements CometDRequest {
                 // TODO: the chunks can be pooled.
                 Input.Chunk chunk = new Chunk();
                 ByteBuffer byteBuffer = chunk.byteBuffer();
-                int read = inputStream.read(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());
+                int read = inputStream.read(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
                 if (read < 0) {
                     chunk.release();
                     return Input.Chunk.EOF;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/BadJSONTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/BadJSONTest.java
@@ -15,6 +15,8 @@
  */
 package org.cometd.server.http;
 
+import java.util.List;
+
 import org.cometd.bayeux.Message;
 import org.cometd.common.JSONContext;
 import org.cometd.common.JettyJSONContextClient;
@@ -90,8 +92,8 @@ public class BadJSONTest extends AbstractBayeuxClientServerTest {
         response = connect.send();
         Assertions.assertEquals(200, response.getStatus());
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] replies = jsonContext.parse(response.getContentAsString());
-        Message.Mutable reply = replies[0];
+        List<Message.Mutable> replies = jsonContext.parse(response.getContentAsString());
+        Message.Mutable reply = replies.get(0);
         Assertions.assertFalse(reply.isSuccessful());
 
         Request subscribe = newBayeuxRequest("[{" +
@@ -102,7 +104,7 @@ public class BadJSONTest extends AbstractBayeuxClientServerTest {
         response = subscribe.send();
         Assertions.assertEquals(200, response.getStatus());
         replies = jsonContext.parse(response.getContentAsString());
-        reply = replies[0];
+        reply = replies.get(0);
         Assertions.assertFalse(reply.isSuccessful());
 
         Request publish = newBayeuxRequest("[{" +
@@ -113,7 +115,7 @@ public class BadJSONTest extends AbstractBayeuxClientServerTest {
         response = publish.send();
         Assertions.assertEquals(200, response.getStatus());
         replies = jsonContext.parse(response.getContentAsString());
-        reply = replies[0];
+        reply = replies.get(0);
         Assertions.assertFalse(reply.isSuccessful());
 
         Request unsubscribe = newBayeuxRequest("[{" +
@@ -124,7 +126,7 @@ public class BadJSONTest extends AbstractBayeuxClientServerTest {
         response = unsubscribe.send();
         Assertions.assertEquals(200, response.getStatus());
         replies = jsonContext.parse(response.getContentAsString());
-        reply = replies[0];
+        reply = replies.get(0);
         Assertions.assertFalse(reply.isSuccessful());
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ConcurrentConnectDisconnectTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ConcurrentConnectDisconnectTest.java
@@ -105,7 +105,7 @@ public class ConcurrentConnectDisconnectTest extends AbstractBayeuxClientServerT
         Assertions.assertEquals(200, response.getStatus());
 
         JettyJSONContextClient parser = new JettyJSONContextClient();
-        Message.Mutable connectReply2 = parser.parse(response.getContentAsString())[0];
+        Message.Mutable connectReply2 = parser.parse(response.getContentAsString()).get(0);
         Assertions.assertFalse(connectReply2.isSuccessful());
         String error = (String)connectReply2.get(Message.ERROR_FIELD);
         Assertions.assertNotNull(error);
@@ -124,7 +124,7 @@ public class ConcurrentConnectDisconnectTest extends AbstractBayeuxClientServerT
                                             "}]");
         response = connect3.send();
         Assertions.assertEquals(200, response.getStatus());
-        Message.Mutable connectReply3 = parser.parse(response.getContentAsString())[0];
+        Message.Mutable connectReply3 = parser.parse(response.getContentAsString()).get(0);
         advice = connectReply3.getAdvice();
         Assertions.assertNotNull(advice);
         Assertions.assertEquals(Message.RECONNECT_HANDSHAKE_VALUE, advice.get(Message.RECONNECT_FIELD));

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/CustomAdviceTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/CustomAdviceTest.java
@@ -15,6 +15,7 @@
  */
 package org.cometd.server.http;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -100,8 +101,8 @@ public class CustomAdviceTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Message.Mutable connect = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Message.Mutable connect = messages.get(0);
         Map<String, Object> advice = connect.getAdvice();
         Assertions.assertNotNull(advice);
         Number timeout = (Number)advice.get("timeout");
@@ -173,8 +174,8 @@ public class CustomAdviceTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Message.Mutable connect = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Message.Mutable connect = messages.get(0);
         Map<String, Object> advice = connect.getAdvice();
         Assertions.assertNotNull(advice);
         Number interval = (Number)advice.get("interval");
@@ -222,8 +223,8 @@ public class CustomAdviceTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Message.Mutable connect = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Message.Mutable connect = messages.get(0);
         Map<String, Object> advice = connect.getAdvice();
         Assertions.assertNotNull(advice);
         Number interval = (Number)advice.get("interval");

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/CustomResponseOnSecurityPolicyDenyTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/CustomResponseOnSecurityPolicyDenyTest.java
@@ -17,6 +17,7 @@ package org.cometd.server.http;
 
 import java.text.ParseException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.cometd.bayeux.Message;
@@ -175,9 +176,9 @@ public class CustomResponseOnSecurityPolicyDenyTest extends AbstractBayeuxClient
 
     private void checkResponse(ContentResponse reply, String reconnectAdvice) throws ParseException {
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] responses = jsonContext.parse(reply.getContentAsString());
-        Assertions.assertEquals(1, responses.length);
-        Message response = responses[0];
+        List<Message.Mutable> responses = jsonContext.parse(reply.getContentAsString());
+        Assertions.assertEquals(1, responses.size());
+        Message response = responses.get(0);
         Map<String, Object> advice = response.getAdvice();
         Assertions.assertNotNull(advice);
         Assertions.assertEquals(reconnectAdvice, advice.get(Message.RECONNECT_FIELD));

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/DisconnectTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/DisconnectTest.java
@@ -84,7 +84,7 @@ public class DisconnectTest extends AbstractBayeuxClientServerTest {
 
         response = listener.get(5, TimeUnit.SECONDS);
         Assertions.assertEquals(200, response.getStatus());
-        Message.Mutable connectReply = new JettyJSONContextClient().parse(response.getContentAsString())[0];
+        Message.Mutable connectReply = new JettyJSONContextClient().parse(response.getContentAsString()).get(0);
         Assertions.assertEquals(Channel.META_CONNECT, connectReply.getChannel());
         Map<String, Object> advice = connectReply.getAdvice(false);
         Assertions.assertEquals(Message.RECONNECT_NONE_VALUE, advice.get(Message.RECONNECT_FIELD));

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/JSONTransportMetaConnectDeliveryTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/JSONTransportMetaConnectDeliveryTest.java
@@ -16,6 +16,7 @@
 package org.cometd.server.http;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.cometd.bayeux.Message;
@@ -74,8 +75,8 @@ public class JSONTransportMetaConnectDeliveryTest extends AbstractBayeuxClientSe
 
         // Expect only the meta response to the publish
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
 
         connect = newBayeuxRequest("[{" +
                                    "\"channel\": \"/meta/connect\"," +
@@ -87,6 +88,6 @@ public class JSONTransportMetaConnectDeliveryTest extends AbstractBayeuxClientSe
 
         // Expect meta response to the connect plus the published message
         messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(2, messages.length);
+        Assertions.assertEquals(2, messages.size());
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/MetaConnectWithOtherMessagesTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/MetaConnectWithOtherMessagesTest.java
@@ -15,6 +15,8 @@
  */
 package org.cometd.server.http;
 
+import java.util.List;
+
 import org.cometd.bayeux.Channel;
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.server.ServerChannel;
@@ -55,14 +57,14 @@ public class MetaConnectWithOtherMessagesTest extends AbstractBayeuxClientServer
         Assertions.assertEquals(200, response.getStatus());
 
         JettyJSONContextClient parser = new JettyJSONContextClient();
-        Message.Mutable[] messages = parser.parse(response.getContentAsString());
+        List<Message.Mutable> messages = parser.parse(response.getContentAsString());
 
-        Assertions.assertEquals(2, messages.length);
+        Assertions.assertEquals(2, messages.size());
 
-        Message.Mutable connectReply = messages[0];
+        Message.Mutable connectReply = messages.get(0);
         Assertions.assertEquals(Channel.META_CONNECT, connectReply.getChannel());
 
-        Message.Mutable subscribeReply = messages[1];
+        Message.Mutable subscribeReply = messages.get(1);
         Assertions.assertEquals(Channel.META_SUBSCRIBE, subscribeReply.getChannel());
 
         ServerChannel channel = bayeux.getChannel(channelName);

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SessionHijackingTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SessionHijackingTest.java
@@ -17,6 +17,7 @@ package org.cometd.server.http;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -40,13 +41,13 @@ public class SessionHijackingTest extends AbstractBayeuxClientServerTest {
         startServer(transport, settings);
 
         // Message should succeed.
-        Message.Mutable[] messages = testSessionHijacking();
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = testSessionHijacking();
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
     }
 
-    private Message.Mutable[] testSessionHijacking() throws UnsupportedEncodingException, InterruptedException, TimeoutException, ExecutionException, java.text.ParseException {
+    private List<Message.Mutable> testSessionHijacking() throws UnsupportedEncodingException, InterruptedException, TimeoutException, ExecutionException, java.text.ParseException {
         String cookieName = "BAYEUX_BROWSER";
 
         Request handshake1 = newBayeuxRequest("[{" +

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SlowConnectionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SlowConnectionTest.java
@@ -89,7 +89,7 @@ public class SlowConnectionTest extends AbstractBayeuxClientServerTest {
         response = connect2.send();
         Assertions.assertEquals(200, response.getStatus());
 
-        Message.Mutable reply = new JettyJSONContextClient().parse(response.getContentAsString())[0];
+        Message.Mutable reply = new JettyJSONContextClient().parse(response.getContentAsString()).get(0);
         Assertions.assertEquals(Channel.META_CONNECT, reply.getChannel());
         Map<String, Object> advice = reply.getAdvice(false);
         if (advice != null) {

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SubscriptionsWithMultipleChannelsTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/SubscriptionsWithMultipleChannelsTest.java
@@ -15,6 +15,8 @@
  */
 package org.cometd.server.http;
 
+import java.util.List;
+
 import org.cometd.bayeux.Message;
 import org.cometd.common.JSONContext;
 import org.cometd.common.JettyJSONContextClient;
@@ -50,9 +52,9 @@ public class SubscriptionsWithMultipleChannelsTest extends AbstractBayeuxClientS
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message.Mutable message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message.Mutable message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
         Object subscriptions = message.get(Message.SUBSCRIPTION_FIELD);
         Assertions.assertTrue(subscriptions instanceof Object[]);
@@ -91,9 +93,9 @@ public class SubscriptionsWithMultipleChannelsTest extends AbstractBayeuxClientS
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message.Mutable message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message.Mutable message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
         Object subscriptions = message.get(Message.SUBSCRIPTION_FIELD);
         Assertions.assertTrue(subscriptions instanceof Object[]);

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/authorizer/AuthorizerTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/authorizer/AuthorizerTest.java
@@ -15,6 +15,8 @@
  */
 package org.cometd.server.http.authorizer;
 
+import java.util.List;
+
 import org.cometd.bayeux.ChannelId;
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.server.Authorizer;
@@ -68,9 +70,9 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertFalse(message.isSuccessful());
 
         publish = newBayeuxRequest("[{" +
@@ -82,8 +84,8 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        message = messages[0];
+        Assertions.assertEquals(1, messages.size());
+        message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
     }
 
@@ -116,9 +118,9 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertFalse(message.isSuccessful());
 
         // Check that publishing to another channel does not involve authorizers
@@ -131,8 +133,8 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        message = messages[0];
+        Assertions.assertEquals(1, messages.size());
+        message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
     }
 
@@ -161,9 +163,9 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
     }
 
@@ -197,9 +199,9 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertFalse(message.isSuccessful());
 
         // Check that publishing to another channel does not involve authorizers
@@ -212,8 +214,8 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        message = messages[0];
+        Assertions.assertEquals(1, messages.size());
+        message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
     }
 
@@ -257,9 +259,9 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client jsonContext = new JettyJSONContextClient();
-        Message.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Message message = messages[0];
+        List<Message.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Message message = messages.get(0);
         Assertions.assertTrue(message.isSuccessful());
 
         // Check that publishing again fails (the authorizer has been removed)
@@ -272,8 +274,8 @@ public class AuthorizerTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        message = messages[0];
+        Assertions.assertEquals(1, messages.size());
+        message = messages.get(0);
         Assertions.assertFalse(message.isSuccessful());
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
@@ -15,6 +15,7 @@
  */
 package org.cometd.server.http.ext;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -124,10 +125,10 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client parser = new JettyJSONContextClient();
-        Message.Mutable[] messages = parser.parse(response.getContentAsString());
-        Assertions.assertEquals(2, messages.length);
-        Message.Mutable m1 = messages[0];
-        Message.Mutable m2 = messages[1];
+        List<Message.Mutable> messages = parser.parse(response.getContentAsString());
+        Assertions.assertEquals(2, messages.size());
+        Message.Mutable m1 = messages.get(0);
+        Message.Mutable m2 = messages.get(1);
         if (channel.equals(m1.getChannel())) {
             Assertions.assertEquals(Channel.META_CONNECT, m2.getChannel());
             Assertions.assertEquals(data, m1.getData());
@@ -237,10 +238,10 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(200, response.getStatus());
 
         JSONContext.Client parser = new JettyJSONContextClient();
-        Message.Mutable[] messages = parser.parse(response.getContentAsString());
-        Assertions.assertEquals(2, messages.length);
-        Message.Mutable m1 = messages[0];
-        Message.Mutable m2 = messages[1];
+        List<Message.Mutable> messages = parser.parse(response.getContentAsString());
+        Assertions.assertEquals(2, messages.size());
+        Message.Mutable m1 = messages.get(0);
+        Message.Mutable m2 = messages.get(1);
         if (channel.equals(m1.getChannel())) {
             Assertions.assertEquals(Channel.META_CONNECT, m2.getChannel());
             Assertions.assertEquals(data, m1.getData());

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/BayeuxExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/BayeuxExtensionTest.java
@@ -15,6 +15,7 @@
  */
 package org.cometd.server.http.ext;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -79,9 +80,9 @@ public class BayeuxExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(CLIENT_INFO, handshakeRef.get().getDataAsMap().get(CLIENT_DATA_FIELD));
 
         JSONContextServer jsonContext = new JettyJSONContextServer();
-        ServerMessage.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(1, messages.length);
-        Map<String, Object> message = messages[0];
+        List<ServerMessage.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(1, messages.size());
+        Map<String, Object> message = messages.get(0);
         Assertions.assertEquals(SERVER_EXT_INFO, message.get(SERVER_EXT_MESSAGE_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.DATA_FIELD)).get(SERVER_EXT_DATA_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.EXT_FIELD)).get(SERVER_EXT_EXT_FIELD));
@@ -128,9 +129,9 @@ public class BayeuxExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(CLIENT_INFO, publishRef.get().getDataAsMap().get(CLIENT_DATA_FIELD));
 
         JSONContextServer jsonContext = new JettyJSONContextServer();
-        ServerMessage.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(2, messages.length);
-        Map<String, Object> message = messages[0].containsKey(Message.DATA_FIELD) ? messages[0] : messages[1];
+        List<ServerMessage.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(2, messages.size());
+        Map<String, Object> message = messages.get(0).containsKey(Message.DATA_FIELD) ? messages.get(0) : messages.get(1);
         Assertions.assertEquals(SERVER_EXT_INFO, message.get(SERVER_EXT_MESSAGE_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.DATA_FIELD)).get(SERVER_EXT_DATA_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.EXT_FIELD)).get(SERVER_EXT_EXT_FIELD));
@@ -189,9 +190,9 @@ public class BayeuxExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(CLIENT_INFO, publishRef.get().getDataAsMap().get(CLIENT_DATA_FIELD));
 
         JSONContextServer jsonContext = new JettyJSONContextServer();
-        ServerMessage.Mutable[] messages = jsonContext.parse(response.getContentAsString());
-        Assertions.assertEquals(2, messages.length);
-        Map<String, Object> message = messages[0].containsKey(Message.DATA_FIELD) ? messages[0] : messages[1];
+        List<ServerMessage.Mutable> messages = jsonContext.parse(response.getContentAsString());
+        Assertions.assertEquals(2, messages.size());
+        Map<String, Object> message = messages.get(0).containsKey(Message.DATA_FIELD) ? messages.get(0) : messages.get(1);
         Assertions.assertEquals(SERVER_EXT_INFO, message.get(SERVER_EXT_MESSAGE_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.DATA_FIELD)).get(SERVER_EXT_DATA_FIELD));
         Assertions.assertEquals(SERVER_EXT_INFO, ((Map)message.get(Message.EXT_FIELD)).get(SERVER_EXT_EXT_FIELD));

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jetty/src/main/java/org/cometd/server/websocket/jetty/JettyWebSocketEndPoint.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jetty/src/main/java/org/cometd/server/websocket/jetty/JettyWebSocketEndPoint.java
@@ -84,8 +84,7 @@ public class JettyWebSocketEndPoint extends AbstractWebSocketEndPoint implements
         _wsSession.close(code, reason, org.eclipse.jetty.websocket.api.Callback.NOOP);
     }
 
-    private void handleFailure(Throwable t)
-    {
+    private void handleFailure(Throwable t) {
         if (_logger.isDebugEnabled()) {
             _logger.debug("", t);
         }

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/SlowConnectionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/SlowConnectionTest.java
@@ -114,7 +114,7 @@ public class SlowConnectionTest extends ClientServerWebSocketTest {
                     "}]";
             wsWrite(output, handshake);
             String text = wsRead(input);
-            Message.Mutable handshakeReply = jsonContext.parse(text)[0];
+            Message.Mutable handshakeReply = jsonContext.parse(text).get(0);
             Assertions.assertEquals(Channel.META_HANDSHAKE, handshakeReply.getChannel());
             Assertions.assertTrue(handshakeReply.isSuccessful());
             String clientId = handshakeReply.getClientId();
@@ -128,7 +128,7 @@ public class SlowConnectionTest extends ClientServerWebSocketTest {
                     "}]";
             wsWrite(output, subscribe);
             text = wsRead(input);
-            Message.Mutable subscribeReply = jsonContext.parse(text)[0];
+            Message.Mutable subscribeReply = jsonContext.parse(text).get(0);
             Assertions.assertEquals(Channel.META_SUBSCRIBE, subscribeReply.getChannel());
             Assertions.assertTrue(subscribeReply.isSuccessful());
 
@@ -142,7 +142,7 @@ public class SlowConnectionTest extends ClientServerWebSocketTest {
                     "}]";
             wsWrite(output, connect1);
             text = wsRead(input);
-            Message.Mutable connect1Reply = jsonContext.parse(text)[0];
+            Message.Mutable connect1Reply = jsonContext.parse(text).get(0);
             Assertions.assertEquals(Channel.META_CONNECT, connect1Reply.getChannel());
             Assertions.assertTrue(connect1Reply.isSuccessful());
             long ack = 0;

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/WebSocketTransportTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/WebSocketTransportTest.java
@@ -16,8 +16,8 @@
 package org.cometd.server.websocket;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -320,8 +320,8 @@ public class WebSocketTransportTest {
         @Override
         public void onWebSocketText(String message) {
             try {
-                Message.Mutable[] mutables = jsonContext.parse(message);
-                Collections.addAll(messages, mutables);
+                List<Message.Mutable> mutables = jsonContext.parse(message);
+                messages.addAll(mutables);
             } catch (Throwable x) {
                 disconnect(session);
             }

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/NetworkDelayListenerTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/NetworkDelayListenerTest.java
@@ -258,7 +258,7 @@ public class NetworkDelayListenerTest extends AbstractClientServerTest {
             socket.read(buffer);
             buffer.flip();
         }
-        return json.parse(BufferUtil.toString(frame.getPayload(), StandardCharsets.UTF_8))[0];
+        return json.parse(BufferUtil.toString(frame.getPayload(), StandardCharsets.UTF_8)).get(0);
     }
 
     private ServerMessage receiveHttpMessage(SocketChannel socket, ByteBuffer buffer, JSONContextServer json) throws Exception {
@@ -272,7 +272,7 @@ public class NetworkDelayListenerTest extends AbstractClientServerTest {
             socket.read(buffer);
             buffer.flip();
         }
-        return json.parse(request.getContent())[0];
+        return json.parse(request.getContent()).get(0);
     }
 
     private void sendMessage(Transport transport, SocketChannel socket, String content) throws IOException {


### PR DESCRIPTION
Removed obsolete methods, not necessary because blocking transports have been removed.
Changed signatures to return List<Message> rather than Message[], to avoid multiple conversions to List.