### PR TITLE
Fixes #1535 - Wrong Jetty version in CometD 6.x/7.x MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,12 +467,11 @@
           </supportedProjectTypes>
           <instructions>
             <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
-            <Bundle-ContactAddress>${project.url}</Bundle-ContactAddress>
             <Bundle-Description>${project.description}</Bundle-Description>
             <Bundle-DocURL>https://docs.cometd.org</Bundle-DocURL>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Import-Package>org.eclipse.jetty.*;version="[9.4,10)",*</Import-Package>
+            <Import-Package>org.eclipse.jetty.*;version="[10,11)",*</Import-Package>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
Updated `Import-Package` with the right Jetty version. Removed `Bundle-ContactAddress`.