### PR TITLE
Change reports to use warning ng and new coverage report for jacoco results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
                 mavenBuild("${env.JDK}", "javadoc:javadoc")
               }
               recordIssues id: "${env.JDK}", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), javaDoc()]
+              recordCoverage(id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 mavenBuild("${env.JDK}", "javadoc:javadoc")
               }
               recordIssues id: "${env.JDK}", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), javaDoc()]
-              recordCoverage(id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
+              recordCoverage(name: "coverage-${env.JDK}", id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
               timeout(time: 15, unit: 'MINUTES') {
                 mavenBuild("${env.JDK}", "javadoc:javadoc")
               }
-              recordIssues id: "${env.JDK}", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), javaDoc()]
+              recordIssues id: "analysis-${env.JDK}", name: "Static Analysis ${env.JDK}", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), javaDoc()]
               recordCoverage(name: "Coverage ${env.JDK}", id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 mavenBuild("${env.JDK}", "javadoc:javadoc")
               }
               recordIssues id: "${env.JDK}", name: "Static Analysis jdk17", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), javaDoc()]
-              recordCoverage(name: "coverage-${env.JDK}", id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
+              recordCoverage(name: "Coverage ${env.JDK}", id: "coverage-${env.JDK}", tools: [[parser: 'JACOCO']], sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'src/main/java']])
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,11 +23,6 @@ pipeline {
             steps {
               timeout(time: 1, unit: 'HOURS') {
                 mavenBuild("${env.JDK}", "clean install")
-                // Collect the JaCoCo execution results.
-                jacoco exclusionPattern: '**/org/webtide/**,**/org/cometd/benchmark/**,**/org/cometd/examples/**',
-                        execPattern: '**/target/jacoco.exec',
-                        classPattern: '**/target/classes',
-                        sourcePattern: '**/src/main/java'
               }
               timeout(time: 15, unit: 'MINUTES') {
                 mavenBuild("${env.JDK}", "javadoc:javadoc")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,9 +60,6 @@ def mavenBuild(jdk, cmdline) {
     }
     finally {
       junit testResults: '**/target/surefire-reports/*.xml,**/target/invoker-reports/TEST*.xml'
-      if (consoleParsers != null) {
-        warnings consoleParsers: consoleParsers
-      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
  * @param cmdline the command line in "<profiles> <goals> <properties>"`format.
  * @param consoleParsers array of console parsers to run
  */
-def mavenBuild(jdk, cmdline, consoleParsers) {
+def mavenBuild(jdk, cmdline) {
   script {
     try {
       withEnv(["JAVA_HOME=${tool "$jdk"}",


### PR DESCRIPTION
- use last maven 3.9.5, remove old warning report to warning-ng report, add javadoc and checkstyle
- fix removed args
- forgot to remove this one
- use new coverage report
- no more old jacoco plugin
- fix name
- magnify name :)
- unify ids
