### PR TITLE
Disable idle timeout in `CometDHandler`

### DIFF
--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
@@ -25,6 +25,7 @@ import org.cometd.server.HttpException;
 import org.cometd.server.ServerSessionImpl;
 import org.cometd.server.http.AbstractHttpTransport;
 import org.cometd.server.http.JSONHttpTransport;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
@@ -117,7 +118,7 @@ public class CometDHandler extends Handler.Abstract {
 
     @Override
     public boolean handle(Request request, Response response, Callback callback) {
-        if ("OPTIONS".equals(request.getMethod())) {
+        if (HttpMethod.OPTIONS.is(request.getMethod())) {
             serviceOptions(request, response, callback);
             return true;
         }
@@ -149,6 +150,7 @@ public class CometDHandler extends Handler.Abstract {
         if (transport == null) {
             Response.writeError(request, response, callback, HttpStatus.BAD_REQUEST_400, "Unknown Bayeux Transport");
         } else {
+            request.addIdleTimeoutListener(x -> false);
             transport.handle(bayeuxContext, cometDRequest, cometDResponse, promise);
         }
         return true;

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/AbstractClientServerTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/AbstractClientServerTest.java
@@ -62,6 +62,10 @@ public abstract class AbstractClientServerTest {
         return EnumSet.allOf(Transport.class);
     }
 
+    public static Collection<Transport> httpTransports() {
+        return EnumSet.of(Transport.JAKARTA_HTTP, Transport.JETTY_HTTP, Transport.OKHTTP_HTTP);
+    }
+
     @RegisterExtension
     public final BeforeTestExecutionCallback printMethodName = context ->
             System.err.printf("Running %s.%s() %s%n", context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), context.getDisplayName());

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
@@ -69,10 +69,8 @@ public class BayeuxClientTest extends AbstractClientServerTest {
 
         client.disconnect();
 
-        for (Message metaMessage : metaMessages)
-        {
-            if (metaMessage instanceof HashMapMessage map)
-            {
+        for (Message metaMessage : metaMessages) {
+            if (metaMessage instanceof HashMapMessage map) {
                 assertThat("Expected no failure: " + map, map.containsKey("failure"), is(false));
             }
         }

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
@@ -43,7 +43,7 @@ public class BayeuxClientTest extends AbstractClientServerTest {
     @MethodSource("transports")
     public void testShortIdleTimeout(Transport transport) throws Exception {
         start(transport);
-        int idleTimeout = 1000;
+        int idleTimeout = 500;
         connector.setIdleTimeout(idleTimeout);
 
         List<Message> metaMessages = new CopyOnWriteArrayList<>();
@@ -66,7 +66,7 @@ public class BayeuxClientTest extends AbstractClientServerTest {
         bayeuxServer.getSession(client.getId()).deliver(null, "/foo", "hello 2", promise2);
         promise2.get();
 
-        disconnectBayeuxClient(client);
+        client.disconnect();
 
         assertThat("Expected 2 messages: " + fooMessages, fooMessages.size(), is(2));
         assertThat(fooMessages.get(0).getData(), is("hello 1"));

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/BayeuxClientTest.java
@@ -43,7 +43,7 @@ public class BayeuxClientTest extends AbstractClientServerTest {
     @MethodSource("transports")
     public void testShortIdleTimeout(Transport transport) throws Exception {
         start(transport);
-        int idleTimeout = 500;
+        int idleTimeout = 1000;
         connector.setIdleTimeout(idleTimeout);
 
         List<Message> metaMessages = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
`CometDHandler` should disable idle timeout as it races with the long-polling timeout

Fixes #1618