### PR TITLE
change default timeout to 20s

### DIFF
--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -52,7 +52,7 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
     private final BayeuxServerImpl _bayeux;
     private long _interval = 0;
     private long _maxInterval = 10000;
-    private long _timeout = 30000;
+    private long _timeout = 20000;
     private long _maxLazyTimeout = 5000;
     private boolean _metaConnectDeliveryOnly = false;
     private JSONContextServer _jsonContext;


### PR DESCRIPTION
Since Jetty's default idle timeout is 30s, using a shorter default CometD timeout will avoid seeing the two race against each other.