### PR TITLE
Fixes #1599 - Wrong processing of Set-Cookie with "expires" with Jetty client.

### DIFF
--- a/cometd-java/cometd-java-benchmark/cometd-java-benchmark-server/src/main/java/org/cometd/benchmark/server/CometDLoadServer.java
+++ b/cometd-java/cometd-java-benchmark/cometd-java-benchmark-server/src/main/java/org/cometd/benchmark/server/CometDLoadServer.java
@@ -500,7 +500,7 @@ public class CometDLoadServer {
             builder.append(request.getHttpURI()).append("\n");
             for (HttpField field : request.getHeaders()) {
                 String name = field.getName();
-                builder.append(name).append("=").append(field.getValueList()).append("\n");
+                builder.append(name).append("=").append(field.getValue()).append("\n");
             }
             builder.append(Request.getRemoteAddr(request)).append(":").append(Request.getRemotePort(request)).append(" => ");
             builder.append(Request.getLocalAddr(request)).append(":").append(Request.getLocalPort(request)).append("\n");

--- a/cometd-java/cometd-java-client/cometd-java-client-common/src/main/java/org/cometd/client/transport/HttpClientTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-common/src/main/java/org/cometd/client/transport/HttpClientTransport.java
@@ -19,9 +19,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpCookieStore;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.SetCookieParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +55,7 @@ public abstract class HttpClientTransport extends ClientTransport {
 
     protected void storeCookies(URI uri, Map<String, List<String>> headers) {
         headers.forEach((key, values) -> {
-            if ("set-cookie".equalsIgnoreCase(key)) {
+            if (HttpHeader.SET_COOKIE.is(key)) {
                 values.forEach(value -> {
                     HttpCookie cookie = cookieParser.parse(value);
                     if (cookie != null) {

--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-jetty/src/main/java/org/cometd/client/http/jetty/JettyHttpClientTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-jetty/src/main/java/org/cometd/client/http/jetty/JettyHttpClientTransport.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.Promise;
 import org.cometd.client.http.common.AbstractHttpClientTransport;
@@ -230,12 +229,12 @@ public class JettyHttpClientTransport extends AbstractHttpClientTransport {
         @Override
         public boolean onHeader(Response response, HttpField field) {
             if (response.getStatus() == HttpStatus.OK_200) {
-                HttpHeader header = field.getHeader();
-                if (header == HttpHeader.SET_COOKIE || header == HttpHeader.SET_COOKIE2) {
+                String name = field.getName();
+                if (HttpHeader.SET_COOKIE.is(name)) {
                     // We do not allow cookies to be handled by HttpClient, since one
                     // HttpClient instance is shared by multiple BayeuxClient instances.
                     // Instead, we store the cookies in the BayeuxClient instance.
-                    Map<String, List<String>> cookies = Map.of(field.getName(), field.getValueList());
+                    Map<String, List<String>> cookies = Map.of(field.getName(), List.of(field.getValue()));
                     storeCookies(cookieURI, cookies);
                     return false;
                 }

--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-jetty/src/main/java/org/cometd/client/http/jetty/JettyHttpClientTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-jetty/src/main/java/org/cometd/client/http/jetty/JettyHttpClientTransport.java
@@ -107,7 +107,7 @@ public class JettyHttpClientTransport extends AbstractHttpClientTransport {
             List<HttpCookie> cookies = getCookies(cookieURI);
             StringBuilder value = new StringBuilder(cookies.size() * 32);
             for (HttpCookie cookie : cookies) {
-                if (value.length() > 0) {
+                if (!value.isEmpty()) {
                     value.append("; ");
                 }
                 value.append(cookie.getName()).append("=").append(cookie.getValue());
@@ -234,7 +234,7 @@ public class JettyHttpClientTransport extends AbstractHttpClientTransport {
                     // We do not allow cookies to be handled by HttpClient, since one
                     // HttpClient instance is shared by multiple BayeuxClient instances.
                     // Instead, we store the cookies in the BayeuxClient instance.
-                    Map<String, List<String>> cookies = Map.of(field.getName(), List.of(field.getValue()));
+                    Map<String, List<String>> cookies = Map.of(name, List.of(field.getValue()));
                     storeCookies(cookieURI, cookies);
                     return false;
                 }

--- a/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-websocket/cometd-java-client-websocket-jetty/src/main/java/org/cometd/client/websocket/jetty/JettyWebSocketTransport.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.cometd.bayeux.Message.Mutable;
 import org.cometd.client.transport.ClientTransport;
 import org.cometd.client.transport.TransportListener;
@@ -42,6 +41,7 @@ import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
@@ -167,7 +167,11 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport implemen
                 if (v == null) {
                     v = new ArrayList<>(1);
                 }
-                v.addAll(field.getValueList());
+                if (HttpHeader.SET_COOKIE.is(k)) {
+                    v.add(field.getValue());
+                } else {
+                    v.addAll(field.getValueList());
+                }
                 return v;
             });
         });

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -131,6 +131,38 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
         }
     }
 
+    protected String getBrowserCookieName() {
+        return _browserCookieName;
+    }
+
+    protected String getBrowserCookieDomain() {
+        return _browserCookieDomain;
+    }
+
+    protected String getBrowserCookiePath() {
+        return _browserCookiePath;
+    }
+
+    protected int getBrowserCookieMaxAge() {
+        return _browserCookieMaxAge;
+    }
+
+    protected boolean isBrowserCookieSecure() {
+        return _browserCookieSecure;
+    }
+
+    protected boolean isBrowserCookieHttpOnly() {
+        return _browserCookieHttpOnly;
+    }
+
+    protected String getBrowserCookieSameSite() {
+        return _browserCookieSameSite;
+    }
+
+    protected boolean isBrowserCookiePartitioned() {
+        return _browserCookiePartitioned;
+    }
+
     protected long getMultiSessionInterval() {
         return _multiSessionInterval;
     }
@@ -451,31 +483,39 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
 
         // Need to support the SameSite attribute so build the cookie manually.
         builder.setLength(0);
-        builder.append(_browserCookieName).append("=").append(browserId);
-        if (_browserCookieDomain != null) {
-            builder.append("; Domain=").append(_browserCookieDomain);
-        }
-        if (_browserCookiePath != null) {
-            builder.append("; Path=").append(_browserCookiePath);
-        }
-        if (_browserCookieMaxAge >= 0) {
-            builder.append("; Max-Age=").append(_browserCookieMaxAge);
-        }
-        if (_browserCookieHttpOnly) {
-            builder.append("; HttpOnly");
-        }
-        if (context.bayeuxContext().isSecure() && _browserCookieSecure) {
-            builder.append("; Secure");
-        }
-        if (_browserCookieSameSite != null) {
-            builder.append("; SameSite=").append(_browserCookieSameSite);
-        }
-        if (_browserCookiePartitioned) {
-            builder.append("; Partitioned");
-        }
+        newBrowserCookie(builder, getBrowserCookieName(), browserId, context.bayeuxContext().isSecure());
         context.response().addHeader("Set-Cookie", builder.toString());
 
         return browserId;
+    }
+
+    protected void newBrowserCookie(StringBuilder builder, String name, String value, boolean secure) {
+        builder.append(name).append("=").append(value);
+        String domain = getBrowserCookieDomain();
+        if (domain != null) {
+            builder.append("; Domain=").append(domain);
+        }
+        String path = getBrowserCookiePath();
+        if (path != null) {
+            builder.append("; Path=").append(path);
+        }
+        int maxAge = getBrowserCookieMaxAge();
+        if (maxAge >= 0) {
+            builder.append("; Max-Age=").append(maxAge);
+        }
+        if (isBrowserCookieHttpOnly()) {
+            builder.append("; HttpOnly");
+        }
+        if (secure && isBrowserCookieSecure()) {
+            builder.append("; Secure");
+        }
+        String sameSite = getBrowserCookieSameSite();
+        if (sameSite != null) {
+            builder.append("; SameSite=").append(sameSite);
+        }
+        if (isBrowserCookiePartitioned()) {
+            builder.append("; Partitioned");
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed handling of the header value in case it is `Set-Cookie`. 
Removed support for `Set-Cookie2`.