### PR TITLE
Fix Typescript Types

### DIFF
--- a/cometd-javascript/common/src/main/webapp/js/cometd/cometd.d.ts
+++ b/cometd-javascript/common/src/main/webapp/js/cometd/cometd.d.ts
@@ -18,6 +18,7 @@ export interface Transport {
     readonly type: string;
     url: string;
     accept(version: string, crossDomain: boolean, url: string): boolean;
+    abort(): void;
 }
 
 export interface TransportRegistry {
@@ -85,14 +86,20 @@ export interface ListenerHandle {
 }
 
 export interface SubscriptionHandle {
+    id: number;
+    channel: string;
+    listener: boolean;
+    callback: Callback;
+    scope?: any;
 }
 
 export type Status = 'disconnected' | 'handshaking' | 'connecting' | 'connected' | 'disconnecting';
 
 export interface Extension {
-    incoming?(message: Message): Message | null;
-
-    outgoing?(message: Message): Message | null;
+    incoming?(message: Message): Message | null | undefined;
+    outgoing?(message: Message): Message | null | undefined;
+    registered?:((name: string, cometd: CometD) => void) | undefined;
+    unregistered?:(() => void) | undefined;
 }
 
 export class CometD {
@@ -110,7 +117,7 @@ export class CometD {
 
     getTransportRegistry(): TransportRegistry;
 
-    configure(options: Configuration): void;
+    configure(options: Configuration | string): void;
 
     handshake(handshakeCallback?: Callback): void;
     handshake(handshakeProps: object, handshakeCallback?: Callback): void;


### PR DESCRIPTION
Extension incoming/outgoing had incorrect types. Returning null from these is different from not returning or returning undefined.

Returning null causes the extension to not work.

Inspired by community provided types https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cometd/index.d.ts

The existing types would work for typescript users that do not have `strict` or `strictNullChecks` enabled as returning undefined or null would not throw a compiler error - but that is not a good practice.