### PR TITLE
Fixes #1716 - WebSocket session leak leads to OOME

### DIFF
--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -291,6 +291,12 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
      */
     public interface Scheduler {
         /**
+         * @return the message associated with this scheduler.
+         */
+        public default ServerMessage.Mutable getMessage() {
+            return null;
+        }
+        /**
          * @return the cycle number for suspended {@code /meta/connect}s.
          */
         public default long getMetaConnectCycle() {

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
-
 import org.cometd.bayeux.Bayeux;
 import org.cometd.bayeux.Channel;
 import org.cometd.bayeux.ChannelId;
@@ -1615,7 +1614,7 @@ public class BayeuxServerImpl extends ContainerLifeCycle implements BayeuxServer
                     long now = System.nanoTime();
                     sweeperInfo.transportSweepDuration = TimeUnit.NANOSECONDS.toMillis(now - previousNanoTime.getAndSet(now));
                     if (_logger.isDebugEnabled()) {
-                        _logger.debug("Swept transports, took {}ms", sweeperInfo.transportSweepDuration);
+                        _logger.debug("Swept transports in {}ms", sweeperInfo.transportSweepDuration);
                     }
                     return runAsync(_channels.values(), serverChannel -> {
                         if (serverChannel.sweep())

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/ServerSessionImpl.java
@@ -550,7 +550,8 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
                         // up and scheduled session expiration,
                         // but here we are suspending, so we must
                         // be sure session expiration is cancelled.
-                        cancelExpiration(true);
+                        boolean metaConnect = Channel.META_CONNECT.equals(newScheduler.getMessage().getChannel());
+                        cancelExpiration(metaConnect);
                     }
                 } else {
                     oldScheduler = newScheduler;
@@ -657,6 +658,10 @@ public class ServerSessionImpl implements ServerSession, Dumpable {
             long currentMetaConnectCycle = getMetaConnectCycle();
             if (metaConnectCycle == 0 || metaConnectCycle == currentMetaConnectCycle) {
                 _expireTime = now + TimeUnit.MILLISECONDS.toNanos(interval + maxInterval);
+                if (_expireTime == 0) {
+                    // Avoid zero because it has a special meaning in sweep().
+                    _expireTime = 1;
+                }
                 if (_logger.isDebugEnabled()) {
                     _logger.debug("Scheduled expiration for {}", this);
                 }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -717,7 +717,6 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
      * <p>A {@link Scheduler} for HTTP-based transports.</p>
      */
     public interface HttpScheduler extends Scheduler {
-        public ServerMessage.Mutable getMessage();
     }
 
     protected abstract class LongPollScheduler implements Runnable, HttpScheduler, AsyncListener {

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractStreamHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractStreamHttpTransport.java
@@ -79,6 +79,8 @@ public abstract class AbstractStreamHttpTransport extends AbstractHttpTransport 
         if (context == null) {
             process(new Context(request, response), promise);
         } else {
+            // We arrive here if we use blocking I/O (DispatchingLongPollScheduler).
+            // The call to asyncContext.dispatch() allows to start a new async cycle.
             ServerMessage.Mutable message = context.scheduler.getMessage();
             context.session.notifyResumed(message, (Boolean)request.getAttribute(HEARTBEAT_TIMEOUT_ATTRIBUTE));
             resume(context, message, Promise.from(y -> flush(context, promise), promise::fail));

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/BayeuxClientWebSocketTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-tests/src/test/java/org/cometd/server/websocket/BayeuxClientWebSocketTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.cometd.bayeux.server.ConfigurableServerChannel.Initializer.Persistent;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BayeuxClientWebSocketTest extends ClientServerWebSocketTest {
     @ParameterizedTest
@@ -1013,5 +1014,48 @@ public class BayeuxClientWebSocketTest extends ClientServerWebSocketTest {
         Assertions.assertTrue(rcv.get().await(5, TimeUnit.SECONDS));
 
         disconnectBayeuxClient(client);
+    }
+
+    @ParameterizedTest
+    @MethodSource("wsTypes")
+    public void testNoMetaConnectSweepsSession(String wsType) throws Exception {
+        long maxInterval = 2000;
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put(AbstractServerTransport.MAX_INTERVAL_OPTION, String.valueOf(maxInterval));
+        prepareAndStart(wsType, initParams);
+
+        BayeuxClient client = newBayeuxClient(wsType);
+
+        CountDownLatch subscribedLatch = new CountDownLatch(1);
+        bayeux.addListener(new BayeuxServer.SubscriptionListener() {
+            @Override
+            public void subscribed(ServerSession session, ServerChannel channel, ServerMessage message) {
+                subscribedLatch.countDown();
+            }
+        });
+        CountDownLatch removedLatch = new CountDownLatch(1);
+        bayeux.addListener(new BayeuxServer.SessionListener() {
+            @Override
+            public void sessionAdded(ServerSession session, ServerMessage message) {
+                session.addListener((ServerSession.RemovedListener)(s, m, t) -> removedLatch.countDown());
+            }
+        });
+
+        client.handshake(message -> {
+            assertTrue(message.isSuccessful());
+
+            try {
+                client.getChannel("/foo").subscribe((c, m) -> {});
+                // Wait here so the /meta/connect is not sent.
+                assertTrue(subscribedLatch.await(5, TimeUnit.SECONDS));
+                // Abort before sending the /meta/connect.
+                client.abort();
+            } catch (Throwable x) {
+                throw new RuntimeException(x);
+            }
+        });
+
+        bayeux.setDetailedDump(true);
+        assertTrue(removedLatch.await(2 * maxInterval, TimeUnit.MILLISECONDS), bayeux.dump());
     }
 }


### PR DESCRIPTION
There was an assumption that a Scheduler was installed only in case of /meta/connect messages. This is true for HTTP, but not WebSocket.

For the WebSocket transport, the Scheduler may be installed after the /meta/handshake, but before the /meta/connect, to allow server-side messages to be published and reach the client with less latency. This was happening, for example, if the first message after the /meta/handshake was a /meta/subscribe.

If no /meta/connect message was sent (e.g. due to the connection being closed), the ServerSession was leaked.

The logic in ServerSessionImpl.setScheduler() is changed to properly cancel the expiration without assuming it is a /meta/connect.

Reviewed logic in AbstractWebSocketEndPoint.WebSocketScheduler.schedule() to take into account the fact that the message may not be a /meta/connect.