### PR TITLE
Fixes #1652 - Cannot access SessionId from BayeuxContext.

### DIFF
--- a/cometd-java/cometd-java-api/cometd-java-api-server/src/main/java/org/cometd/bayeux/server/BayeuxContext.java
+++ b/cometd-java/cometd-java-api/cometd-java-api-server/src/main/java/org/cometd/bayeux/server/BayeuxContext.java
@@ -91,6 +91,13 @@ public interface BayeuxContext {
     Object getRequestAttribute(String name);
 
     /**
+     * <p>Returns the HTTP session id, or {@code null} if there is no HTTP session.</p>
+     *
+     * @return the HTTP session id, or {@code null} if there is no HTTP session
+     */
+    String getSessionId();
+
+    /**
      * <p>Returns an HTTP session attribute value.</p>
      * <p>{@link ServerSession#getAttribute(String)} should be used to retrieve
      * attribute values in session scope.</p>

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaBayeuxContext.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaBayeuxContext.java
@@ -99,6 +99,12 @@ class JakartaBayeuxContext implements BayeuxContext {
     }
 
     @Override
+    public String getSessionId() {
+        HttpSession session = request.getSession(false);
+        return session == null ? null : session.getId();
+    }
+
+    @Override
     public Object getSessionAttribute(String name) {
         HttpSession session = request.getSession(false);
         return session != null ? session.getAttribute(name) : null;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/JettyBayeuxContext.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/JettyBayeuxContext.java
@@ -96,6 +96,12 @@ class JettyBayeuxContext implements BayeuxContext {
     }
 
     @Override
+    public String getSessionId() {
+        Session session = request.getSession(false);
+        return session == null ? null : session.getId();
+    }
+
+    @Override
     public Object getSessionAttribute(String name) {
         Session session = request.getSession(false);
         return session == null ? null : session.getAttribute(name);

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-common/src/main/java/org/cometd/server/websocket/common/AbstractBayeuxContext.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-common/src/main/java/org/cometd/server/websocket/common/AbstractBayeuxContext.java
@@ -139,6 +139,11 @@ public abstract class AbstractBayeuxContext implements BayeuxContext {
     }
 
     @Override
+    public String getSessionId() {
+        return null;
+    }
+
+    @Override
     public Object getSessionAttribute(String name) {
         return null;
     }

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jakarta/src/main/java/org/cometd/server/websocket/jakarta/WebSocketTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jakarta/src/main/java/org/cometd/server/websocket/jakarta/WebSocketTransport.java
@@ -111,6 +111,7 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
     private static class JakartaWebSocketContext extends AbstractBayeuxContext {
         private final Map<String, Object> contextAttributes;
         private final Map<String, Object> requestAttributes;
+        private final String sessionId;
         private final Map<String, Object> sessionAttributes;
 
         private JakartaWebSocketContext(ServletContext context, HandshakeRequest request, Map<String, Object> userProperties) {
@@ -123,7 +124,9 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
                     WebSocketTransport.isSecure(request));
             contextAttributes = Map.copyOf(attributesToMap(context));
             requestAttributes = Map.of();
-            sessionAttributes = Map.copyOf(attributesToMap((HttpSession)request.getHttpSession()));
+            HttpSession httpSession = (HttpSession)request.getHttpSession();
+            sessionId = httpSession == null ? null : httpSession.getId();
+            sessionAttributes = Map.copyOf(attributesToMap(httpSession));
         }
 
         private static Map<String, Object> attributesToMap(ServletContext context) {
@@ -154,6 +157,11 @@ public class WebSocketTransport extends AbstractWebSocketTransport {
         @Override
         public Object getRequestAttribute(String name) {
             return requestAttributes.get(name);
+        }
+
+        @Override
+        public String getSessionId() {
+            return sessionId;
         }
 
         @Override

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jetty/src/main/java/org/cometd/server/websocket/jetty/JettyWebSocketTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-jetty/src/main/java/org/cometd/server/websocket/jetty/JettyWebSocketTransport.java
@@ -131,6 +131,7 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport {
     private static class JettyWebSocketContext extends AbstractBayeuxContext {
         private final Map<String, Object> contextAttributes;
         private final Map<String, Object> requestAttributes;
+        private final String sessionId;
         private final Map<String, Object> sessionAttributes;
 
         private JettyWebSocketContext(ServerUpgradeRequest request) {
@@ -141,6 +142,7 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport {
             this.contextAttributes = Map.copyOf(request.getContext().asAttributeMap());
             this.requestAttributes = Map.copyOf(request.asAttributeMap());
             Session session = request.getSession(false);
+            this.sessionId = session == null ? null : session.getId();
             this.sessionAttributes = session == null ? Map.of() : Map.copyOf(session.asAttributeMap());
         }
 
@@ -184,6 +186,11 @@ public class JettyWebSocketTransport extends AbstractWebSocketTransport {
         @Override
         public Object getRequestAttribute(String name) {
             return requestAttributes.get(name);
+        }
+
+        @Override
+        public String getSessionId() {
+            return sessionId;
         }
 
         @Override


### PR DESCRIPTION
Restored `BayeuxContext.getSessionId()`.
