### PR TITLE
Updated Jetty to 12.0.9.

### DIFF
--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -19,6 +19,7 @@ package org.cometd.server;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.cometd.bayeux.Promise;
 import org.cometd.bayeux.server.ServerMessage;
@@ -286,6 +287,10 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
          * that will trigger when the /meta/connect timeout fires.
          */
         public default void cancel() {
+            cancel(new TimeoutException());
+        }
+
+        public default void cancel(Throwable cause) {
         }
 
         /**

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -1626,7 +1626,7 @@ public class BayeuxServerImpl extends ContainerLifeCycle implements BayeuxServer
                         _lastSweepInfo = sweeperInfo;
                         if (_logger.isDebugEnabled()) {
                             _logger.debug("Swept server sessions, {} in {}ms", sweeperInfo.serverSessionSweepCount, sweeperInfo.serverSessionSweepDuration);
-                            _logger.debug("End of async sweep in {}ns at {}", sweeperInfo.sweepDurationNanos, Instant.now());
+                            _logger.debug("End of async sweep in {}ms at {}", TimeUnit.NANOSECONDS.toMillis(sweeperInfo.sweepDurationNanos), Instant.now());
                         }
                     });
         }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/CometDRequest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/CometDRequest.java
@@ -19,6 +19,7 @@ package org.cometd.server;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * <p>An abstraction over HTTP requests.</p>
@@ -70,6 +71,14 @@ public interface CometDRequest {
      * @param value the attribute value
      */
     void setAttribute(String name, Object value);
+
+    /**
+     * <p>Adds the given handler function to be invoked
+     * when a failure is detected for this request.</p>
+     *
+     * @param handler the failure handler function
+     */
+    void addFailureHandler(Consumer<Throwable> handler);
 
     /**
      * <p>The source of the request body.</p>

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpScheduler.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpScheduler.java
@@ -16,7 +16,6 @@
 
 package org.cometd.server.http;
 
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.cometd.bayeux.Promise;
 import org.cometd.bayeux.server.ServerMessage;
@@ -72,12 +71,12 @@ public abstract class AbstractHttpScheduler implements Runnable, AbstractHttpTra
     }
 
     @Override
-    public void cancel() {
+    public void cancel(Throwable cause) {
         if (cancelTimeout()) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Cancelling suspended {} for {}", message, context.session());
             }
-            error(new TimeoutException());
+            error(cause);
         }
     }
 
@@ -117,6 +116,7 @@ public abstract class AbstractHttpScheduler implements Runnable, AbstractHttpTra
 
     protected void error(Throwable failure) {
         CometDRequest request = context.request();
+        transport.scheduleExpiration(context.session(), getMetaConnectCycle());
         transport.decBrowserId(context.session(), transport.isHTTP2(request));
         getPromise().fail(failure);
     }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -374,8 +374,7 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
                             HttpScheduler scheduler = suspend(context, promise, message, timeout);
                             // Setting the scheduler may resume the /meta/connect.
                             session.setScheduler(scheduler);
-                            // TODO pass failure to scheduler.cancel()?
-                            request.addFailureHandler(failure -> scheduler.cancel());
+                            request.addFailureHandler(scheduler::cancel);
                             proceed = false;
                         } else {
                             decBrowserId(session, isHTTP2(request));

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -372,8 +372,10 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
                             // session will decide atomically if we need to resume or not.
 
                             HttpScheduler scheduler = suspend(context, promise, message, timeout);
-                            // Setting the scheduler may resume the /meta/connect
+                            // Setting the scheduler may resume the /meta/connect.
                             session.setScheduler(scheduler);
+                            // TODO pass failure to scheduler.cancel()?
+                            request.addFailureHandler(failure -> scheduler.cancel());
                             proceed = false;
                         } else {
                             decBrowserId(session, isHTTP2(request));

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/CometDServlet.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/CometDServlet.java
@@ -116,8 +116,13 @@ public class CometDServlet extends HttpServlet {
 
             @Override
             public void fail(Throwable failure) {
-                int code = failure instanceof HttpException http ? http.getCode() : HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-                sendError(request, response, code, failure);
+                int code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+                Throwable cause = failure;
+                if (failure instanceof HttpException http) {
+                    code = http.getCode();
+                    cause = http.getCause();
+                }
+                sendError(request, response, code, cause);
                 asyncContext.complete();
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Handling failed", failure);

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
@@ -195,7 +195,13 @@ class JakartaCometDRequest implements CometDRequest {
         }
     }
 
-    private record FailureListener(Consumer<Throwable> handler) implements AsyncListener {
+    private static class FailureListener implements AsyncListener {
+        private final Consumer<Throwable> handler;
+
+        private FailureListener(Consumer<Throwable> handler) {
+            this.handler = handler;
+        }
+
         @Override
         public void onComplete(AsyncEvent event) {
         }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jakarta/src/main/java/org/cometd/server/http/jakarta/JakartaCometDRequest.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.Cookie;
@@ -90,6 +93,11 @@ class JakartaCometDRequest implements CometDRequest {
     @Override
     public void setAttribute(String name, Object value) {
         request.setAttribute(name, value);
+    }
+
+    @Override
+    public void addFailureHandler(Consumer<Throwable> handler) {
+        request.getAsyncContext().addListener(new FailureListener(handler));
     }
 
     private static class JakartaCometDInput implements Input, ReadListener {
@@ -184,6 +192,25 @@ class JakartaCometDRequest implements CometDRequest {
             public String toString() {
                 return "%s@%x[last=%b,%s]".formatted(getClass().getSimpleName(), hashCode(), isLast(), byteBuffer());
             }
+        }
+    }
+
+    private record FailureListener(Consumer<Throwable> handler) implements AsyncListener {
+        @Override
+        public void onComplete(AsyncEvent event) {
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) {
+            handler.accept(event.getThrowable());
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) {
         }
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
@@ -171,6 +171,6 @@ public class CometDHandler extends Handler.Abstract {
     }
 
     protected void sendError(Request request, Response response, Callback callback, int code, Throwable failure) {
-        Response.writeError(request, response, callback, code);
+        Response.writeError(request, response, callback, code, null, failure);
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/CometDHandler.java
@@ -139,8 +139,13 @@ public class CometDHandler extends Handler.Abstract {
 
             @Override
             public void fail(Throwable failure) {
-                int code = failure instanceof HttpException http ? http.getCode() : HttpStatus.INTERNAL_SERVER_ERROR_500;
-                sendError(request, response, callback, code, failure);
+                int code = HttpStatus.INTERNAL_SERVER_ERROR_500;
+                Throwable cause = failure;
+                if (failure instanceof HttpException http) {
+                    code = http.getCode();
+                    cause = http.getCause();
+                }
+                sendError(request, response, callback, code, cause);
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Handling failed", failure);
                 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/JettyCometDRequest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-jetty/src/main/java/org/cometd/server/http/jetty/JettyCometDRequest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.function.Consumer;
 import org.cometd.server.CometDRequest;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.io.Content;
@@ -87,6 +88,11 @@ class JettyCometDRequest implements CometDRequest {
     @Override
     public void setAttribute(String name, Object value) {
         request.setAttribute(name, value);
+    }
+
+    @Override
+    public void addFailureHandler(Consumer<Throwable> handler) {
+        request.addFailureListener(handler);
     }
 
     private static class JettyCometDInput implements Input {

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
@@ -47,42 +47,53 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         startServer(transport, null);
         bayeux.addExtension(new AcknowledgedMessagesExtension());
 
-        Request handshake = newBayeuxRequest("[{" +
-                                             "\"channel\": \"/meta/handshake\"," +
-                                             "\"version\": \"1.0\"," +
-                                             "\"minimumVersion\": \"1.0\"," +
-                                             "\"supportedConnectionTypes\": [\"long-polling\"]," +
-                                             "\"ext\": { \"ack\": true }" +
-                                             "}]");
+        Request handshake = newBayeuxRequest("""
+                [{
+                "id": "0",
+                "channel": "/meta/handshake",
+                "version": "1.0",
+                "minimumVersion": "1.0",
+                "supportedConnectionTypes": ["long-polling"],
+                "ext": { "ack": true }
+                }]
+                """);
         ContentResponse response = handshake.send();
         Assertions.assertEquals(200, response.getStatus());
 
         String clientId = extractClientId(response);
 
-        Request connect = newBayeuxRequest("[{" +
-                                           "\"channel\": \"/meta/connect\"," +
-                                           "\"clientId\": \"" + clientId + "\"," +
-                                           "\"connectionType\": \"long-polling\"," +
-                                           "\"ext\": { \"ack\": -1 }" +
-                                           "}]");
+        Request connect = newBayeuxRequest("""
+                [{
+                "id": "1",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": -1 }
+                }]
+                """.formatted(clientId));
         response = connect.send();
         Assertions.assertEquals(200, response.getStatus());
 
         String channel = "/foo";
-        Request subscribe = newBayeuxRequest("[{" +
-                                             "\"channel\": \"/meta/subscribe\"," +
-                                             "\"clientId\": \"" + clientId + "\"," +
-                                             "\"subscription\": \"" + channel + "\"" +
-                                             "}]");
+        Request subscribe = newBayeuxRequest("""
+                [{
+                "id": "2",
+                "channel": "/meta/subscribe",
+                "clientId": "%s",
+                "subscription": "%s"
+                }]
+                """.formatted(clientId, channel));
         response = subscribe.send();
         Assertions.assertEquals(200, response.getStatus());
 
-        connect = newBayeuxRequest("[{" +
-                                   "\"channel\": \"/meta/connect\"," +
-                                   "\"clientId\": \"" + clientId + "\"," +
-                                   "\"connectionType\": \"long-polling\"," +
-                                   "\"ext\": { \"ack\": 0 }" +
-                                   "}]");
+        connect = newBayeuxRequest("""
+                [{
+                "id": "3",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": 0 }
+                }]""".formatted(clientId));
         connect.send(null);
         // Wait for the long poll.
         Thread.sleep(1000);
@@ -101,7 +112,8 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         bayeux.getChannel(channel).publish(null, data, Promise.noop());
         // Wait for the message to be lost.
         Thread.sleep(1000);
-        Assertions.assertEquals(0, session.getQueue().size());
+        // TODO: fix comments above
+        Assertions.assertEquals(1, session.getQueue().size());
 
         connector.setPort(port);
         connector.start();
@@ -112,12 +124,15 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(1, ackQueue.size());
 
         // Send the same /meta/connect *without* advice: { timeout: 0 }.
-        connect = newBayeuxRequest("[{" +
-                                   "\"channel\": \"/meta/connect\"," +
-                                   "\"clientId\": \"" + clientId + "\"," +
-                                   "\"connectionType\": \"long-polling\"," +
-                                   "\"ext\": { \"ack\": 0 }" +
-                                   "}]");
+        connect = newBayeuxRequest("""
+                [{
+                "id": "4",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": 0 }
+                }]
+                """.formatted(clientId));
         CompletableFuture<ContentResponse> listener = new CompletableResponseListener(connect).send();
 
         // It must return immediately because there is a message in the unacknowledged queue.
@@ -138,10 +153,13 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
             Assertions.assertEquals(data, m2.getData());
         }
 
-        Request disconnect = newBayeuxRequest("[{" +
-                                              "\"channel\": \"/meta/disconnect\"," +
-                                              "\"clientId\": \"" + clientId + "\"" +
-                                              "}]");
+        Request disconnect = newBayeuxRequest("""
+                [{
+                "id": "5",
+                "channel": "/meta/disconnect",
+                "clientId": "?"
+                }]
+                """.formatted(clientId));
         response = disconnect.send();
         Assertions.assertEquals(200, response.getStatus());
     }
@@ -153,42 +171,54 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         startServer(transport, null);
         bayeux.addExtension(new AcknowledgedMessagesExtension());
 
-        Request handshake = newBayeuxRequest("[{" +
-                                             "\"channel\": \"/meta/handshake\"," +
-                                             "\"version\": \"1.0\"," +
-                                             "\"minimumVersion\": \"1.0\"," +
-                                             "\"supportedConnectionTypes\": [\"long-polling\"]," +
-                                             "\"ext\": { \"ack\": true }" +
-                                             "}]");
+        Request handshake = newBayeuxRequest("""
+                [{
+                "id": "0",
+                "channel": "/meta/handshake",
+                "version": "1.0",
+                "minimumVersion": "1.0",
+                "supportedConnectionTypes": ["long-polling"],
+                "ext": { "ack": true }
+                }]
+                """);
         ContentResponse response = handshake.send();
         Assertions.assertEquals(200, response.getStatus());
 
         String clientId = extractClientId(response);
 
-        Request connect = newBayeuxRequest("[{" +
-                                           "\"channel\": \"/meta/connect\"," +
-                                           "\"clientId\": \"" + clientId + "\"," +
-                                           "\"connectionType\": \"long-polling\"," +
-                                           "\"ext\": { \"ack\": -1 }" +
-                                           "}]");
+        Request connect = newBayeuxRequest("""
+                [{
+                "id": "1",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": -1 }
+                }]
+                """.formatted(clientId));
         response = connect.send();
         Assertions.assertEquals(200, response.getStatus());
 
         String channel = "/foo";
-        Request subscribe = newBayeuxRequest("[{" +
-                                             "\"channel\": \"/meta/subscribe\"," +
-                                             "\"clientId\": \"" + clientId + "\"," +
-                                             "\"subscription\": \"" + channel + "\"" +
-                                             "}]");
+        Request subscribe = newBayeuxRequest("""
+                [{
+                "id": "2",
+                "channel": "/meta/subscribe",
+                "clientId": "%s",
+                "subscription": "%s"
+                }]
+                """.formatted(clientId, channel));
         response = subscribe.send();
         Assertions.assertEquals(200, response.getStatus());
 
-        connect = newBayeuxRequest("[{" +
-                                   "\"channel\": \"/meta/connect\"," +
-                                   "\"clientId\": \"" + clientId + "\"," +
-                                   "\"connectionType\": \"long-polling\"," +
-                                   "\"ext\": { \"ack\": 0 }" +
-                                   "}]");
+        connect = newBayeuxRequest("""
+                [{
+                "id": "3",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": 0 }
+                }]
+                """.formatted(clientId));
         connect.send(null);
         // Wait for the long poll.
         Thread.sleep(1000);
@@ -218,18 +248,21 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         Assertions.assertEquals(1, ackQueue.size());
 
         // Send the same /meta/connect *without* advice: { timeout: 0 }.
-        connect = newBayeuxRequest("[{" +
-                                   "\"channel\": \"/meta/connect\"," +
-                                   "\"clientId\": \"" + clientId + "\"," +
-                                   "\"connectionType\": \"long-polling\"," +
-                                   "\"ext\": { \"ack\": 0 }" +
-                                   "}]");
+        connect = newBayeuxRequest("""
+                [{
+                "id": "4",
+                "channel": "/meta/connect",
+                "clientId": "%s",
+                "connectionType": "long-polling",
+                "ext": { "ack": 0 }
+                }]
+                """.formatted(clientId));
         CompletableFuture<ContentResponse> listener = new CompletableResponseListener(connect).send();
 
         // It must be held because there are only lazy messages.
         try {
-            listener.get(1, TimeUnit.SECONDS);
-            Assertions.fail();
+            response = listener.get(1, TimeUnit.SECONDS);
+            Assertions.fail(response.toString());
         } catch (TimeoutException x) {
             // Expected.
         }
@@ -251,10 +284,13 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
             Assertions.assertEquals(data, m2.getData());
         }
 
-        Request disconnect = newBayeuxRequest("[{" +
-                                              "\"channel\": \"/meta/disconnect\"," +
-                                              "\"clientId\": \"" + clientId + "\"" +
-                                              "}]");
+        Request disconnect = newBayeuxRequest("""
+                [{
+                "id": "5",
+                "channel": "/meta/disconnect",
+                "clientId": "%s"
+                }]
+                """.formatted(clientId));
         response = disconnect.send();
         Assertions.assertEquals(200, response.getStatus());
     }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
@@ -98,7 +98,7 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
         // Wait for the long poll.
         Thread.sleep(1000);
 
-        // Stop the connector so a server-side publish will get lost.
+        // Stop the connector so a server-side publish will not be delivered.
         int port = connector.getLocalPort();
         connector.stop();
         // Wait to process the close.
@@ -106,13 +106,12 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
 
         ServerSessionImpl session = (ServerSessionImpl)bayeux.getSession(clientId);
 
-        // Publish the message; it will get lost but the
-        // ack extension will track it and resend it later.
+        // Publish the message; the ack extension will track it and resend it later.
         String data = "data";
         bayeux.getChannel(channel).publish(null, data, Promise.noop());
         // Wait for the message to be lost.
         Thread.sleep(1000);
-        // TODO: fix comments above
+
         Assertions.assertEquals(1, session.getQueue().size());
 
         connector.setPort(port);
@@ -157,7 +156,7 @@ public class AcknowledgeExtensionTest extends AbstractBayeuxClientServerTest {
                 [{
                 "id": "5",
                 "channel": "/meta/disconnect",
-                "clientId": "?"
+                "clientId": "%s"
                 }]
                 """.formatted(clientId));
         response = disconnect.send();

--- a/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/WebAppTest.java
+++ b/cometd-java/cometd-java-tests/cometd-java-tests-common/src/test/java/org/cometd/tests/WebAppTest.java
@@ -171,6 +171,7 @@ public class WebAppTest {
         addServerDependency(org.eclipse.jetty.server.Deployable.class, serverClassPath);
         addServerDependency(org.eclipse.jetty.session.SessionManager.class, serverClassPath);
         addServerDependency(org.eclipse.jetty.util.ajax.JSON.class, serverClassPath);
+        addServerDependency(org.eclipse.jetty.ee.WebAppClassLoading.class, serverClassPath);
         addServerDependency(org.eclipse.jetty.ee10.webapp.WebAppContext.class, serverClassPath);
         addServerDependency(org.eclipse.jetty.websocket.api.Session.class, serverClassPath);
         addServerDependency(org.eclipse.jetty.websocket.common.WebSocketSession.class, serverClassPath);

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <jackson-version>2.17.0</jackson-version>
     <jakarta-ee-version>10.0.0</jakarta-ee-version>
     <!-- tag::jetty-version[] -->
-    <jetty-version>12.0.8</jetty-version>
+    <jetty-version>12.0.9</jetty-version>
     <!-- end::jetty-version[] -->
     <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
     <maven-war-plugin-version>3.4.0</maven-war-plugin-version>


### PR DESCRIPTION
Updated CometD to new behavior of Jetty 12.0.9 where stopping the ServerConnector triggers the failure of suspended requests.