### PR TITLE
Fixes #1770 - Suspended sessions are leaked with HTTP/2 reset.

### DIFF
--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/HTTP2ClientResetTest.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/HTTP2ClientResetTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cometd.client.http;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.cometd.bayeux.Message;
+import org.cometd.bayeux.server.ServerSession;
+import org.cometd.common.JettyJSONContextClient;
+import org.cometd.server.AbstractServerTransport;
+import org.cometd.server.BayeuxServerImpl;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HTTP2ClientResetTest extends HTTP2ClientServerTest {
+    @Test
+    public void testClientResetAfterMetaHandshakeSessionIsSwept() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        long sweepPeriod = 500;
+        options.put(BayeuxServerImpl.SWEEP_PERIOD_OPTION, String.valueOf(sweepPeriod));
+        long maxInterval = 2000;
+        options.put(AbstractServerTransport.MAX_INTERVAL_OPTION, String.valueOf(maxInterval));
+        start(options);
+        bayeux.setDetailedDump(true);
+
+        Promise.Completable<Session> sessionPromise = new Promise.Completable<>();
+        http2Client.connect(new InetSocketAddress("localhost", connector.getLocalPort()), new Session.Listener.Adapter(), sessionPromise);
+        Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+        CountDownLatch removedLatch = new CountDownLatch(1);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from(cometdURL), HttpVersion.HTTP_2, HttpFields.EMPTY);
+        Promise.Completable<Stream> streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback) {
+                try {
+                    String json = UTF_8.decode(frame.getData()).toString();
+                    Message reply = new JettyJSONContextClient().parse(json)[0];
+                    assertEquals(true, reply.get(Message.SUCCESSFUL_FIELD));
+                    String sessionId = (String)reply.get(Message.CLIENT_ID_FIELD);
+                    ServerSession cometdSession = bayeux.getSession(sessionId);
+                    cometdSession.addListener((ServerSession.RemovedListener)(s, m, t) -> removedLatch.countDown());
+
+                    // Send a reset to the server.
+                    stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+                } catch (Throwable x) {
+                    callback.failed(x);
+                }
+            }
+        });
+        Stream stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaHandshake = "[{" +
+                "\"id\": \"1\"," +
+                "\"channel\": \"/meta/handshake\"," +
+                "\"supportedConnectionTypes\": [\"long-polling\"]" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaHandshake), true), Callback.NOOP);
+
+        // Do not send the /meta/connect
+
+        // Wait for the server-side session to expire.
+        assertTrue(removedLatch.await(2 * maxInterval, TimeUnit.MILLISECONDS), bayeux.dump());
+    }
+
+    @Test
+    public void testClientResetAfterFirstMetaConnectSessionIsSwept() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        long sweepPeriod = 500;
+        options.put(BayeuxServerImpl.SWEEP_PERIOD_OPTION, String.valueOf(sweepPeriod));
+        long maxInterval = 2000;
+        options.put(AbstractServerTransport.MAX_INTERVAL_OPTION, String.valueOf(maxInterval));
+        start(options);
+        bayeux.setDetailedDump(true);
+
+        Promise.Completable<Session> sessionPromise = new Promise.Completable<>();
+        http2Client.connect(new InetSocketAddress("localhost", connector.getLocalPort()), new Session.Listener.Adapter(), sessionPromise);
+        Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+        AtomicReference<HttpFields> handshakeResponseRef = new AtomicReference<>();
+        AtomicReference<Message> handshakeReplyRef = new AtomicReference<>();
+        CountDownLatch handshakeLatch = new CountDownLatch(1);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from(cometdURL), HttpVersion.HTTP_2, HttpFields.EMPTY);
+        Promise.Completable<Stream> streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame) {
+                handshakeResponseRef.set(frame.getMetaData().getFields());
+            }
+
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback) {
+                try {
+                    String json = UTF_8.decode(frame.getData()).toString();
+                    Message reply = new JettyJSONContextClient().parse(json)[0];
+                    handshakeReplyRef.set(reply);
+                    handshakeLatch.countDown();
+                } catch (Throwable x) {
+                    callback.failed(x);
+                }
+            }
+        });
+        Stream stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaHandshake = "[{" +
+                "\"id\": \"1\"," +
+                "\"channel\": \"/meta/handshake\"," +
+                "\"supportedConnectionTypes\": [\"long-polling\"]" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaHandshake), true), Callback.NOOP);
+
+        assertTrue(handshakeLatch.await(5, TimeUnit.SECONDS));
+        Message handshakeReply = handshakeReplyRef.get();
+        assertEquals(true, handshakeReply.get(Message.SUCCESSFUL_FIELD));
+        String cookie = handshakeResponseRef.get().get(HttpHeader.SET_COOKIE);
+        cookie = cookie.substring(0, cookie.indexOf(";"));
+        String sessionId = (String)handshakeReply.get(Message.CLIENT_ID_FIELD);
+
+        CountDownLatch removedLatch = new CountDownLatch(1);
+        HttpFields headers = HttpFields.build().put(HttpHeader.COOKIE, cookie);
+        request = new MetaData.Request("POST", HttpURI.from(cometdURL), HttpVersion.HTTP_2, headers);
+        streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback) {
+                try {
+                    String json = UTF_8.decode(frame.getData()).toString();
+                    Message reply = new JettyJSONContextClient().parse(json)[0];
+                    assertEquals(true, reply.get(Message.SUCCESSFUL_FIELD));
+                    ServerSession cometdSession = bayeux.getSession(sessionId);
+                    cometdSession.addListener((ServerSession.RemovedListener)(s, m, t) -> removedLatch.countDown());
+
+                    // Send a reset to the server.
+                    stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+                } catch (Throwable x) {
+                    callback.failed(x);
+                }
+            }
+        });
+        stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaConnect = "[{" +
+                "\"id\":\"2\"," +
+                "\"channel\":\"/meta/connect\"," +
+                "\"connectionType\":\"long-polling\"," +
+                "\"clientId\":\"" + sessionId + "\"," +
+                "\"advice\": {\"timeout\":0}" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaConnect), true), Callback.NOOP);
+
+        // Wait for the server-side session to expire.
+        assertTrue(removedLatch.await(2 * maxInterval, TimeUnit.MILLISECONDS), bayeux.dump());
+    }
+
+    @Test
+    public void testClientResetAfterSuspendedMetaConnectSessionIsSwept() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        long sweepPeriod = 500;
+        options.put(BayeuxServerImpl.SWEEP_PERIOD_OPTION, String.valueOf(sweepPeriod));
+        long maxInterval = 2000;
+        options.put(AbstractServerTransport.MAX_INTERVAL_OPTION, String.valueOf(maxInterval));
+        long timeout = 3000;
+        options.put(AbstractServerTransport.TIMEOUT_OPTION, String.valueOf(timeout));
+        start(options);
+        bayeux.setDetailedDump(true);
+
+        Promise.Completable<Session> sessionPromise = new Promise.Completable<>();
+        http2Client.connect(new InetSocketAddress("localhost", connector.getLocalPort()), new Session.Listener.Adapter(), sessionPromise);
+        Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+        AtomicReference<HttpFields> metaHandshakeResponseRef = new AtomicReference<>();
+        AtomicReference<Message> metaHandshakeReplyRef = new AtomicReference<>();
+        CountDownLatch metaHandshakeLatch = new CountDownLatch(1);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from(cometdURL), HttpVersion.HTTP_2, HttpFields.EMPTY);
+        Promise.Completable<Stream> streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame) {
+                metaHandshakeResponseRef.set(frame.getMetaData().getFields());
+            }
+
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback) {
+                try {
+                    String json = UTF_8.decode(frame.getData()).toString();
+                    Message reply = new JettyJSONContextClient().parse(json)[0];
+                    metaHandshakeReplyRef.set(reply);
+                    metaHandshakeLatch.countDown();
+                } catch (Throwable x) {
+                    callback.failed(x);
+                }
+            }
+        });
+        Stream stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaHandshake = "[{" +
+                "\"id\": \"1\"," +
+                "\"channel\": \"/meta/handshake\"," +
+                "\"supportedConnectionTypes\": [\"long-polling\"]" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaHandshake), true), Callback.NOOP);
+
+        assertTrue(metaHandshakeLatch.await(5, TimeUnit.SECONDS));
+        Message metaHandshakeReply = metaHandshakeReplyRef.get();
+        assertEquals(true, metaHandshakeReply.get(Message.SUCCESSFUL_FIELD));
+        String cookie = metaHandshakeResponseRef.get().get(HttpHeader.SET_COOKIE);
+        cookie = cookie.substring(0, cookie.indexOf(";"));
+        String sessionId = (String)metaHandshakeReply.get(Message.CLIENT_ID_FIELD);
+
+        AtomicReference<Message> metaConnectReplyRef = new AtomicReference<>();
+        CountDownLatch metaConnectLatch1 = new CountDownLatch(1);
+        HttpFields headers = HttpFields.build().put(HttpHeader.COOKIE, cookie);
+        request = new MetaData.Request("POST", HttpURI.from(cometdURL), HttpVersion.HTTP_2, headers);
+        streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onData(Stream stream, DataFrame frame, Callback callback) {
+                try {
+                    String json = UTF_8.decode(frame.getData()).toString();
+                    Message reply = new JettyJSONContextClient().parse(json)[0];
+                    metaConnectReplyRef.set(reply);
+                    metaConnectLatch1.countDown();
+                } catch (Throwable x) {
+                    callback.failed(x);
+                }
+            }
+        });
+        stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaConnect1 = "[{" +
+                "\"id\":\"2\"," +
+                "\"channel\":\"/meta/connect\"," +
+                "\"connectionType\":\"long-polling\"," +
+                "\"clientId\":\"" + sessionId + "\"," +
+                "\"advice\": {\"timeout\":0}" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaConnect1), true), Callback.NOOP);
+
+        assertTrue(metaConnectLatch1.await(5, TimeUnit.SECONDS));
+        Message metaConnectReply = metaConnectReplyRef.get();
+        assertEquals(true, metaConnectReply.get(Message.SUCCESSFUL_FIELD));
+
+        CountDownLatch metaConnectLatch2 = new CountDownLatch(1);
+        streamPromise = new Promise.Completable<>();
+        session.newStream(new HeadersFrame(request, null, false), streamPromise, new Stream.Listener.Adapter() {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame) {
+                metaConnectLatch2.countDown();
+            }
+        });
+        stream = streamPromise.get(5, TimeUnit.SECONDS);
+
+        String metaConnect2 = "[{" +
+                "\"id\":\"3\"," +
+                "\"channel\":\"/meta/connect\"," +
+                "\"connectionType\":\"long-polling\"," +
+                "\"clientId\":\"" + sessionId + "\"" +
+                "}]";
+        stream.data(new DataFrame(stream.getId(), UTF_8.encode(metaConnect2), true), Callback.NOOP);
+
+        // The /meta/connect must have been suspended, wait half of the timeout to be sure.
+        assertFalse(metaConnectLatch2.await(timeout / 2, TimeUnit.MILLISECONDS));
+
+        CountDownLatch removedLatch = new CountDownLatch(1);
+        ServerSession cometdSession = bayeux.getSession(sessionId);
+        cometdSession.addListener((ServerSession.RemovedListener)(s, m, t) -> removedLatch.countDown());
+
+        // Send a reset to the server.
+        stream.reset(new ResetFrame(stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
+
+        // Wait for the server-side session to expire.
+        assertTrue(removedLatch.await(2 * maxInterval, TimeUnit.MILLISECONDS), bayeux.dump());
+    }
+}

--- a/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/HTTP2ClientServerTest.java
+++ b/cometd-java/cometd-java-client/cometd-java-client-http/cometd-java-client-http-tests/src/test/java/org/cometd/client/http/HTTP2ClientServerTest.java
@@ -25,6 +25,8 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 
 public class HTTP2ClientServerTest extends ClientServerTest {
+    protected HTTP2Client http2Client;
+
     @Override
     protected void startServer(Map<String, String> initParams, ConnectionFactory... connectionFactories) throws Exception {
         HttpConfiguration httpConfig = new HttpConfiguration();
@@ -33,7 +35,8 @@ public class HTTP2ClientServerTest extends ClientServerTest {
 
     @Override
     protected void startClient() throws Exception {
-        httpClient = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client()));
+        http2Client = new HTTP2Client();
+        httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
         httpClient.start();
     }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/AbstractServerTransport.java
@@ -18,6 +18,7 @@ package org.cometd.server;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.cometd.bayeux.Promise;
 import org.cometd.bayeux.server.ServerMessage;
@@ -296,6 +297,7 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
         public default ServerMessage.Mutable getMessage() {
             return null;
         }
+
         /**
          * @return the cycle number for suspended {@code /meta/connect}s.
          */
@@ -315,6 +317,15 @@ public abstract class AbstractServerTransport extends AbstractTransport implemen
          * that will trigger when the /meta/connect timeout fires.
          */
         public default void cancel() {
+            cancel(new TimeoutException());
+        }
+
+        /**
+         * Invoked when the transport wants to cancel with the given
+         * cause scheduled operations that will trigger when the
+         * /meta/connect timeout fires.
+         */
+        public default void cancel(Throwable cause) {
         }
 
         /**

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AbstractHttpTransport.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.AsyncContext;
@@ -777,12 +776,12 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
         }
 
         @Override
-        public void cancel() {
+        public void cancel(Throwable cause) {
             if (cancelTimeout()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Cancelling suspended {} for {}", message, context.session);
                 }
-                error(new TimeoutException());
+                fail(cause);
             }
         }
 
@@ -832,13 +831,14 @@ public abstract class AbstractHttpTransport extends AbstractServerTransport {
 
         @Override
         public void onError(AsyncEvent event) {
-            error(event.getThrowable());
+            cancel(event.getThrowable());
         }
 
         protected abstract void dispatch(boolean timeout);
 
-        private void error(Throwable failure) {
+        private void fail(Throwable failure) {
             HttpServletRequest request = context.request;
+            scheduleExpiration(context.session, getMetaConnectCycle());
             decBrowserId(context.session, isHTTP2(request));
             promise.fail(failure);
         }

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AsyncJSONTransport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/http/AsyncJSONTransport.java
@@ -172,6 +172,7 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
         private final Context context;
         private final Promise<Void> promise;
         private int total;
+        private boolean eof;
 
         protected AbstractReader(Context context, Promise<Void> promise) {
             this.context = context;
@@ -210,6 +211,11 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
             }
         }
 
+        @Override
+        public void onAllDataRead() throws IOException {
+            eof = true;
+        }
+
         protected abstract void append(byte[] buffer, int offset, int length);
 
         protected void finish(List<ServerMessage.Mutable> messages) throws IOException {
@@ -228,6 +234,28 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
 
         @Override
         public void onError(Throwable failure) {
+            // Some implementations report HTTP/2 RST_STREAM to
+            // the ReadListener, rather than to the AsyncListener,
+            // even after the request content has been fully read.
+            // Make sure we fail the scheduler if a /meta/connect
+            // is suspended, so that the session can be swept.
+            Scheduler scheduler = context.scheduler;
+            if (scheduler != null) {
+                scheduler.cancel(failure);
+                return;
+            }
+
+            // A failure after having read the request content
+            // is ignored, since the request is currently being
+            // processed and will notice the failure when writing
+            // the reply, which will schedule session expiration
+            // if the request is a non-suspended /meta/connect.
+            if (eof) {
+                return;
+            }
+
+            // Otherwise, the failure is during the read,
+            // therefore we must fail the current promise.
             promise.fail(failure);
         }
     }
@@ -252,6 +280,7 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
 
         @Override
         public void onAllDataRead() throws IOException {
+            super.onAllDataRead();
             List<ServerMessage.Mutable> messages = parser.complete();
             finish(messages);
         }
@@ -291,6 +320,7 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
 
         @Override
         public void onAllDataRead() throws IOException {
+            super.onAllDataRead();
             finish(new String(content, 0, count, charset));
         }
     }
@@ -375,7 +405,7 @@ public class AsyncJSONTransport extends AbstractHttpTransport {
 
         private boolean writeHandshakeReply(ServletOutputStream output) throws IOException {
             List<ServerMessage.Mutable> replies = context.replies;
-            if (replies.size() > 0) {
+            if (!replies.isEmpty()) {
                 ServerMessage.Mutable reply = replies.get(0);
                 if (Channel.META_HANDSHAKE.equals(reply.getChannel())) {
                     if (allowMessageDeliveryDuringHandshake(context.session) && !messages.isEmpty()) {

--- a/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-common/src/main/java/org/cometd/server/websocket/common/AbstractWebSocketEndPoint.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-websocket/cometd-java-server-websocket-common/src/main/java/org/cometd/server/websocket/common/AbstractWebSocketEndPoint.java
@@ -409,7 +409,7 @@ public abstract class AbstractWebSocketEndPoint {
         }
 
         @Override
-        public void cancel() {
+        public void cancel(Throwable cause) {
             if (cancelTimeout(true)) {
                 if (_logger.isDebugEnabled()) {
                     _logger.debug("Cancelling suspended {} for {} on {}", message, context.session, AbstractWebSocketEndPoint.this);


### PR DESCRIPTION
An HTTP/2 reset was causing AsyncListener.onError() to be invoked, and that in turn was calling LongPollScheduler.error(), which was not scheduling the session for expiration.

Fixed by having AsyncListener.onError() call Scheduler.cancel(), and LongPollScheduler.error() call scheduleExpiration(), so that the ServerSession can be swept.

(cherry picked from commit fed1148bdca4472bf876db537f5e4c8d5340e344)