### PR TITLE
Fixes #1782 - Allow CometDServlet to always instantiate a BayeuxServer.

### DIFF
--- a/cometd-documentation/src/main/asciidoc/java_oort.adoc
+++ b/cometd-documentation/src/main/asciidoc/java_oort.adoc
@@ -50,7 +50,7 @@ For both static and automatic discovery there exists a set of parameters that yo
 The following is the list of common configuration parameters the automatic discovery and static configuration servlets share:
 
 .Oort Common Configuration Parameters
-[cols="5a,1a,4a,8a", options="header"]
+[cols="<5a,^1a,<5a,<8a", options="header"]
 |===
 | Parameter Name
 | Required
@@ -92,6 +92,11 @@ The following is the list of common configuration parameters the automatic disco
 | no
 | The Jakarta WebSocket and the Jetty HTTP `ClientTransport.Factory` implementations
 | A comma-separated list of fully qualified class names of `ClientTransport.Factory` implementations used to create `OortComet` transports
+
+| oortContextAttributeName
+| no
+| org.cometd.oort.Oort
+| The context attribute name under which the `Oort` object is stored, for web applications to retrieve.
 |===
 
 ==== Automatic Discovery Configuration

--- a/cometd-documentation/src/main/asciidoc/java_oort_seti.adoc
+++ b/cometd-documentation/src/main/asciidoc/java_oort_seti.adoc
@@ -11,7 +11,22 @@ Keep the following points in mind when configuring Seti:
 * You must configure an `org.cometd.oort.Seti` instance with an associated `org.cometd.oort.Oort` instance, either via code or by configuring an `org.cometd.oort.SetiServlet` in `web.xml`.
 * There may be only one instance of `Seti` for each `Oort`.
 * The `load-on-startup` parameter of the `SetiServlet` must be greater than that of the Oort configuration Servlet.
-* `SetiServlet` does not have any configuration init parameter.
+
+`SetiServlet` has the following configuration init parameters:
+
+.Seti Configuration Parameters
+[cols="<5a,^1a,<5a,<8a", options="header"]
+|===
+| Parameter Name
+| Required
+| Default Value
+| Parameter Description
+
+| setiContextAttributeName
+| no
+| org.cometd.oort.Seti
+| The context attribute name under which the `Seti` object is stored, for web applications to retrieve.
+|===
 
 A configuration example follows:
 
@@ -46,7 +61,7 @@ A configuration example follows:
 
     <servlet>
         <servlet-name>seti</servlet-name>
-        <servlet-class>org.cometd.oort.jakarta.SetiServletorg.cometd.oort.jakarta.SetiServlet</servlet-class>
+        <servlet-class>org.cometd.oort.jakarta.SetiServlet</servlet-class>
         <load-on-startup>3</load-on-startup>
     </servlet>
 </web-app>

--- a/cometd-documentation/src/main/asciidoc/java_server_configuration.adoc
+++ b/cometd-documentation/src/main/asciidoc/java_server_configuration.adoc
@@ -42,7 +42,7 @@ It is normally mapped to `+/cometd/*+`, but you can change the `url-pattern` map
 Here is the list of configuration init parameters that the `BayeuxServer` implementation accepts:
 
 .`BayeuxServer` Configuration Parameters
-[cols="^2,^3,<10"]
+[cols="<4a,^5a,<10a"]
 |===
 | Parameter Name
 | Default Value
@@ -59,7 +59,7 @@ Here is the list of configuration init parameters that the `BayeuxServer` implem
   This property can be overridden at the channel level and at the session level.
 
 | jsonContext
-| `org.cometd.server.JettyJSONContextServer`
+| org.cometd.server.JettyJSONContextServer
 | The full qualified name of a class implementing `org.cometd.server.JSONContextServer`.
   The class is loaded and instantiated using the default constructor.
 
@@ -88,6 +88,10 @@ Here is the list of configuration init parameters that the `BayeuxServer` implem
 | 128
 | The max number of executor threads that execute jobs.
   The scheduler is used by transports such as WebSocket that don't have threading support from the Servlet Container.
+
+| bayeuxServerContextAttributeName
+| org.cometd.bayeux
+| The context attribute name under which the `BayeuxServer` instance is stored, for web applications to retrieve.
 |===
 
 [[_java_server_configuration_transports]]

--- a/cometd-documentation/src/main/asciidoc/java_server_services_integration.adoc
+++ b/cometd-documentation/src/main/asciidoc/java_server_services_integration.adoc
@@ -42,8 +42,8 @@ Here is a sample `web.xml`:
 
 Notice that the `web.xml` file specifies `<load-on-startup>` to be:
 
-* 1 for the CometD servlet -- so that the Bayeux object gets created and put in the `ServletContext`.
-* 2 for the configuration servlet -- so that it will be initialized only after the CometD servlet has been initialized and hence the BayeuxServer object is available.
+* 1 for the `CometDServlet` -- so that the `BayeuxServer` object gets created and put in the `ServletContext`.
+* 2 for the configuration servlet -- so that it will be initialized only after the CometD servlet has been initialized and hence the `BayeuxServer` object is available.
 
 This is the code for the `ConfigurationServlet`:
 
@@ -51,6 +51,43 @@ This is the code for the `ConfigurationServlet`:
 ----
 include::{doc_code}/server/ServerServiceIntegrationDocs.java[tags=configServlet]
 ----
+
+Note that the `BayeuxServer` object can be retrieved from the `ServletContext` under the attribute name `BayeuxServer.ATTRIBUTE`.
+The attribute name is configurable via an `init-param` of the `CometDServlet`:
+
+[source,xml,subs=+quotes]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+  <servlet>
+    <servlet-name>cometd</servlet-name>
+    <servlet-class>org.cometd.server.http.jakarta.CometDServlet</servlet-class>
+    #<init-param>#
+      #<param-name>bayeuxServerContextAttributeName</param-name>#
+      #<param-value>myBayeuxServer</param-value>#
+    #</init-param>#
+    <load-on-startup>1</load-on-startup>
+    <async-supported>true</async-supported>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>cometd</servlet-name>
+    <url-pattern>/cometd/*</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+    <servlet-name>configuration</servlet-name>
+    <servlet-class>com.acme.cometd.ConfigurationServlet</servlet-class>
+    <load-on-startup>2</load-on-startup>
+  </servlet>
+
+</web-app>
+----
+
+In the `ConfigurationServlet` you can now retrieve the `BayeuxServer` object using the attribute name `myBayeuxServer`.
 
 See also xref:_java_server_services_inherited[this section] about the `EchoService`.
 

--- a/cometd-java/cometd-java-api/cometd-java-api-server/src/main/java/org/cometd/bayeux/server/BayeuxServer.java
+++ b/cometd-java/cometd-java-api/cometd-java-api-server/src/main/java/org/cometd/bayeux/server/BayeuxServer.java
@@ -25,9 +25,11 @@ import org.cometd.bayeux.client.ClientSessionChannel;
 
 /**
  * <p>The server-side Bayeux interface.</p>
- * <p>An instance of the {@link BayeuxServer} interface is available to
- * web applications via the "{@value #ATTRIBUTE}" attribute
- * of the {@code javax.servlet.ServletContext}.</p>
+ * <p>An instance of the {@link BayeuxServer} interface is available
+ * by default to web applications via the {@value #ATTRIBUTE} attribute
+ * of the web application context (for Servlet environments,
+ * the {@code javax.servlet.ServletContext}).
+ * The context attribute name can be configured as an option.</p>
  * <p>The {@link BayeuxServer} APIs give access to the
  * {@link ServerSession}s via the {@link #getSession(String)}
  * method.  It also allows new {@link LocalSession} to be

--- a/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-common/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -84,6 +84,7 @@ public class BayeuxServerImpl extends ContainerLifeCycle implements BayeuxServer
     public static final String BROADCAST_TO_PUBLISHER_OPTION = "broadcastToPublisher";
     public static final String SCHEDULER_THREADS = "schedulerThreads";
     public static final String EXECUTOR_MAX_THREADS = "executorMaxThreads";
+    public static final String CONTEXT_ATTRIBUTE_NAME_OPTION = "bayeuxServerContextAttributeName";
     private static final long DEFAULT_SWEEP_PERIOD = 997;
     private static final int DEFAULT_SWEEP_THREADS = 2;
 

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/AbstractBayeuxServerTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/AbstractBayeuxServerTest.java
@@ -102,8 +102,4 @@ public abstract class AbstractBayeuxServerTest {
             server.stop();
         }
     }
-
-    public enum Transport {
-        JAKARTA, JETTY
-    }
 }

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ManyBayeuxServersTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ManyBayeuxServersTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cometd.server.http;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.cometd.bayeux.server.BayeuxServer;
+import org.cometd.server.BayeuxServerImpl;
+import org.cometd.server.http.jakarta.CometDServlet;
+import org.cometd.server.http.jetty.CometDHandler;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.PathMappingsHandler;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ManyBayeuxServersTest {
+    public static Transport[] transports() {
+        return Transport.values();
+    }
+
+    @RegisterExtension
+    public final BeforeTestExecutionCallback printMethodName = context ->
+            System.err.printf("Running %s.%s() %s%n", context.getRequiredTestClass().getSimpleName(), context.getRequiredTestMethod().getName(), context.getDisplayName());
+    private Server server;
+    private ServerConnector connector;
+    private Context context;
+
+    public void startServer(Transport transport, Map<String, String> options1, Map<String, String> options2) throws Exception {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        switch (transport) {
+            case JAKARTA -> {
+                ServletContextHandler servletContext = new ServletContextHandler("/");
+                server.setHandler(servletContext);
+                context = servletContext.getContext();
+
+                ServletHolder servletHolder1 = new ServletHolder(new CometDServlet());
+                servletHolder1.setInitParameters(options1);
+                servletContext.addServlet(servletHolder1, "/cometd1/*");
+
+                ServletHolder servletHolder2 = new ServletHolder(new CometDServlet());
+                servletHolder2.setInitParameters(options2);
+                servletContext.addServlet(servletHolder2, "/cometd2/*");
+            }
+            case JETTY -> {
+                PathMappingsHandler pathsHandler = new PathMappingsHandler();
+                server.setHandler(pathsHandler);
+                context = server.getContext();
+
+                CometDHandler handler1 = new CometDHandler();
+                handler1.setOptions(options1);
+                pathsHandler.addMapping(PathSpec.from("/cometd1/*"), handler1);
+
+                CometDHandler handler2 = new CometDHandler();
+                handler2.setOptions(options2);
+                pathsHandler.addMapping(PathSpec.from("/cometd2/*"), handler2);
+            }
+        }
+
+        server.start();
+    }
+
+
+    @AfterEach
+    public void stopServer() {
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testManyBayeuxServers(Transport transport) throws Exception {
+        Map<String, String> options1 = new HashMap<>();
+        String contextAttributeName1 = "org.cometd.bayeux.server.1";
+        options1.put(BayeuxServerImpl.CONTEXT_ATTRIBUTE_NAME_OPTION, contextAttributeName1);
+
+        Map<String, String> options2 = new HashMap<>();
+        String contextAttributeName2 = "org.cometd.bayeux.server.2";
+        options2.put(BayeuxServerImpl.CONTEXT_ATTRIBUTE_NAME_OPTION, contextAttributeName2);
+
+        startServer(transport, options1, options2);
+
+        assertNull(context.getAttribute(BayeuxServer.ATTRIBUTE));
+        BayeuxServer bayeuxServer1 = (BayeuxServer)context.getAttribute(contextAttributeName1);
+        assertNotNull(bayeuxServer1);
+        BayeuxServer bayeuxServer2 = (BayeuxServer)context.getAttribute(contextAttributeName2);
+        assertNotNull(bayeuxServer2);
+        assertNotSame(bayeuxServer1, bayeuxServer2);
+    }
+}

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/Transport.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/Transport.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cometd.server.http;
+
+public enum Transport {
+    JAKARTA, JETTY
+}

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/authorizer/AuthorizerTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/authorizer/AuthorizerTest.java
@@ -27,6 +27,7 @@ import org.cometd.common.JSONContext;
 import org.cometd.common.JettyJSONContextClient;
 import org.cometd.server.authorizer.GrantAuthorizer;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/AcknowledgeExtensionTest.java
@@ -32,6 +32,7 @@ import org.cometd.server.ext.AcknowledgedMessagesExtension;
 import org.cometd.server.ext.AcknowledgedMessagesSessionExtension;
 import org.cometd.server.ext.BatchArrayQueue;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.CompletableResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/BayeuxExtensionTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/BayeuxExtensionTest.java
@@ -30,6 +30,7 @@ import org.cometd.server.BayeuxServerImpl;
 import org.cometd.server.JSONContextServer;
 import org.cometd.server.JettyJSONContextServer;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionConnectTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionConnectTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionDisconnectTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionDisconnectTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionHandshakeTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionHandshakeTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionPublishReceivedTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionPublishReceivedTest.java
@@ -27,6 +27,7 @@ import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.AbstractService;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionPublishSentTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionPublishSentTest.java
@@ -23,6 +23,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionSubscribeTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionSubscribeTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionUnsubscribeTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/ext/ExtensionUnsubscribeTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;

--- a/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/filter/JSONDataFilterTest.java
+++ b/cometd-java/cometd-java-server/cometd-java-server-http/cometd-java-server-http-tests/src/test/java/org/cometd/server/http/filter/JSONDataFilterTest.java
@@ -24,6 +24,7 @@ import org.cometd.bayeux.server.ServerSession;
 import org.cometd.server.filter.DataFilterMessageListener;
 import org.cometd.server.filter.NoScriptsFilter;
 import org.cometd.server.http.AbstractBayeuxClientServerTest;
+import org.cometd.server.http.Transport;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Introduced and documented new parameters to make the context attribute name configurable. This allows web applications to create multiple BayeuxServer instances with different configurations under different names and map them to different URI paths.