### PR TITLE
Disable option detectOfflineLinks for javdoc plugin to make build faster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
           agent { node { label "linux-light" } }
           steps {
             timeout(time: 15, unit: "MINUTES") {
-              mavenBuild("jdk21", "clean install -DskipTests javadoc:javadoc", false)
+              mavenBuild("jdk21", "clean install -DskipTests javadoc:jar", false)
             }
           }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,8 @@
   </distributionManagement>
 
   <properties>
+    <!-- javadoc option only useful for Maven site build and slow down build -->
+    <detectOfflineLinks>false</detectOfflineLinks>
     <dojo-version>1.17.3</dojo-version>
     <!-- Last GraalVM version to support Java 8 -->
     <graalvm-version>21.3.2.1</graalvm-version>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
