### PR TITLE
- Added WebSocketTransport typing

### DIFF
--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/LongPollingTransport.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/LongPollingTransport.d.ts
@@ -1,0 +1,13 @@
+import {Transport} from "./Transport";
+
+export class LongPollingTransport extends Transport {
+    protected xhrSend(packet: {
+        transport: LongPollingTransport,
+        url: string,
+        sync: boolean,
+        headers: object,
+        body: string,
+        onSuccess: (response: string) => void,
+        onError: (reason: string, exception?: Error) => void
+    }): XMLHttpRequest;
+}

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/Transport.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/Transport.d.ts
@@ -1,0 +1,45 @@
+import { CometD, Configuration } from "./cometd";
+
+/**
+ * Base class with the common functionality for transports.
+ */
+export abstract class Transport {
+    url: string;
+
+    /**
+     * Function invoked just after a transport has been successfully registered.
+     * @param type the type of transport (for example "long-polling")
+     * @param cometd the cometd object this transport has been registered to
+     * @see #unregistered()
+     */
+    registered(type: string, cometd: CometD): void;
+
+    /**
+     * Function invoked just after a transport has been successfully unregistered.
+     * @see #registered(type, cometd)
+     */
+    unregistered(): void;
+
+    readonly cometd: CometD;
+    readonly configuration: Configuration;
+
+    /**
+     * Returns whether this transport can work for the given version and cross domain communication case.
+     * @param version a string indicating the transport version
+     * @param crossDomain a boolean indicating whether the communication is cross domain
+     * @param url the URL to connect to
+     * @return true if this transport can work for the given version and cross domain communication case,
+     * false otherwise
+     */
+    accept(version: string, crossDomain: boolean, url: string): boolean;
+
+    /**
+     * Returns the type of this transport.
+     * @see #registered(type, cometd)
+     */
+    readonly type: string;
+
+    reset(init: boolean): void;
+
+    abort(): void;
+}

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
@@ -1,0 +1,4 @@
+import {Transport} from "./Transport";
+
+export class WebSocketTransport extends Transport {
+}

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-export interface Transport {
-    readonly type: string;
-    url: string;
+export * from "./Transport";
+export * from "./LongPollingTransport";
+export * from "./WebSocketTransport";
 
-    accept(version: string, crossDomain: boolean, url: string): boolean;
-    abort(): void;
-}
+import { Transport } from "./Transport";
 
 export interface TransportRegistry {
     getTransportTypes(): string[];
@@ -41,14 +39,22 @@ export interface Advice {
     hosts?: string[];
 }
 
-export interface Message {
+export interface Failure extends Advice {
+    connectionType?: string;
+    reason?: string;
+    httpCode?: string;
+    websocketCode?: string;
+}
+
+export interface Message<T = any> {
     advice?: Advice;
     channel: string;
     clientId?: string;
     connectionType?: string;
-    data?: any;
+    data?: T;
     error?: string;
     ext?: object;
+    failure?: Failure;
     id?: string;
     minimumVersion?: string;
     reestablish?: boolean;
@@ -59,7 +65,7 @@ export interface Message {
     version?: string;
 }
 
-export type Callback = (message: Message) => void;
+export type Callback<T = any> = (message: Message<T>) => void;
 
 export type LogLevel = "warn" | "info" | "debug";
 
@@ -115,45 +121,45 @@ export class CometD {
 
     configure(options: Configuration | string): void;
 
-    handshake(handshakeCallback?: Callback): void;
-    handshake(handshakeProps: object, handshakeCallback?: Callback): void;
+    handshake<T = any>(handshakeCallback?: Callback<T>): void;
+    handshake<T = any>(handshakeProps: object, handshakeCallback?: Callback<T>): void;
 
-    disconnect(disconnectCallback?: Callback): void;
-    disconnect(disconnectProps: object, disconnectCallback?: Callback): void;
+    disconnect<T = any>(disconnectCallback?: Callback<T>): void;
+    disconnect<T = any>(disconnectProps: object, disconnectCallback?: Callback<T>): void;
 
     batch(group: () => void): void;
 
-    addListener(channel: string, messageCallback: Callback): ListenerHandle;
+    addListener<T = any>(channel: string, messageCallback: Callback<T>): ListenerHandle;
 
     removeListener(handle: ListenerHandle): void;
 
     clearListeners(): void;
 
-    subscribe(channel: string, messageCallback: Callback, subscribeCallback?: Callback): SubscriptionHandle;
-    subscribe(channel: string, messageCallback: Callback, subscribeProps: object, subscribeCallback?: Callback): SubscriptionHandle;
+    subscribe<T = any>(channel: string, messageCallback: Callback<T>, subscribeCallback?: Callback<T>): SubscriptionHandle;
+    subscribe<T = any>(channel: string, messageCallback: Callback<T>, subscribeProps: object, subscribeCallback?: Callback<T>): SubscriptionHandle;
 
-    unsubscribe(handle: SubscriptionHandle, unsubscribeCallback?: Callback): void;
-    unsubscribe(handle: SubscriptionHandle, unsubscribeProps: object, unsubscribeCallback?: Callback): void;
+    unsubscribe<T = any>(handle: SubscriptionHandle, unsubscribeCallback?: Callback<T>): void;
+    unsubscribe<T = any>(handle: SubscriptionHandle, unsubscribeProps: object, unsubscribeCallback?: Callback<T>): void;
 
     resubscribe(handle: SubscriptionHandle, subscribeProps?: object): SubscriptionHandle;
 
     clearSubscriptions(): void;
 
-    publish(channel: string, content: any, publishCallback?: Callback): void;
-    publish(channel: string, content: any, publishProps: object, publishCallback?: Callback): void;
+    publish<T = any>(channel: string, content: any, publishCallback?: Callback<T>): void;
+    publish<T = any>(channel: string, content: any, publishProps: object, publishCallback?: Callback<T>): void;
 
-    publishBinary(channel: string, data: any, last: boolean, publishCallback?: Callback): void;
-    publishBinary(channel: string, data: any, last: boolean, meta: object, publishCallback?: Callback): void;
-    publishBinary(channel: string, data: any, last: boolean, meta: object, publishProps: object, publishCallback?: Callback): void;
+    publishBinary<T = any>(channel: string, data: any, last: boolean, publishCallback?: Callback<T>): void;
+    publishBinary<T = any>(channel: string, data: any, last: boolean, meta: object, publishCallback?: Callback<T>): void;
+    publishBinary<T = any>(channel: string, data: any, last: boolean, meta: object, publishProps: object, publishCallback?: Callback<T>): void;
 
-    remoteCall(target: string, content: any, callback?: Callback): void;
-    remoteCall(target: string, content: any, timeout: number, callback?: Callback): void;
-    remoteCall(target: string, content: any, timeout: number, callProps: object, callback?: Callback): void;
+    remoteCall<T = any>(target: string, content: any, callback?: Callback<T>): void;
+    remoteCall<T = any>(target: string, content: any, timeout: number, callback?: Callback<T>): void;
+    remoteCall<T = any>(target: string, content: any, timeout: number, callProps: object, callback?: Callback<T>): void;
 
-    remoteCallBinary(target: string, data: any, last: boolean, callback?: Callback): void;
-    remoteCallBinary(target: string, data: any, last: boolean, meta: object, callback?: Callback): void;
-    remoteCallBinary(target: string, data: any, last: boolean, meta: object, timeout: number, callback?: Callback): void;
-    remoteCallBinary(target: string, data: any, last: boolean, meta: object, timeout: number, callProps: object, callback?: Callback): void;
+    remoteCallBinary<T = any>(target: string, data: any, last: boolean, callback?: Callback<T>): void;
+    remoteCallBinary<T = any>(target: string, data: any, last: boolean, meta: object, callback?: Callback<T>): void;
+    remoteCallBinary<T = any>(target: string, data: any, last: boolean, meta: object, timeout: number, callback?: Callback<T>): void;
+    remoteCallBinary<T = any>(target: string, data: any, last: boolean, meta: object, timeout: number, callProps: object, callback?: Callback<T>): void;
 
     getStatus(): Status;
 
@@ -192,6 +198,8 @@ export class CometD {
     reload?(): void;
 
     websocketEnabled?: boolean;
+
+    onListenerException?: (error: Error, subscription: unknown, listener: SubscriptionHandle, message: Message) => void;
 }
 
 export type Bytes = number[] | ArrayBuffer | DataView |


### PR DESCRIPTION
Hello,
Here a proposal of Typescript typings upgrade (so only typings, no code change).
In particular:
- Exposed LongPollingTransport and WebSocketTransport
- Transformed Transport from interface to base class, and moved in a different file
- Make Message as generic <T> (by default uses any, so backward compatible)
- Exposed Message.failure
- Exposed onListenerException in get/set (it seems a public API)

Thanks, L.
