### PR TITLE
- Exposed createWebSocket for customization

### DIFF
--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
@@ -1,0 +1,5 @@
+import {Transport} from "./Client";
+
+export class WebSocketTransport implements Transport {
+    protected createWebSocket(url: string, protocol: string): WebSocket;
+}

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
@@ -97,6 +97,10 @@ export class WebSocketTransport extends Transport {
         }
     }
 
+    createWebSocket(url, protocol) {
+        return protocol ? new window.WebSocket(url, protocol) : new window.WebSocket(url);
+    }
+
     #websocketConnect(context) {
         // We may have multiple attempts to open a WebSocket
         // connection, for example a /meta/connect request that
@@ -112,7 +116,7 @@ export class WebSocketTransport extends Transport {
 
         try {
             const protocol = this.configuration.protocol;
-            context.webSocket = protocol ? new window.WebSocket(url, protocol) : new window.WebSocket(url);
+            context.webSocket = this.createWebSocket(url, protocol);
             this.#connecting = context;
         } catch (x) {
             this.#webSocketSupported = false;

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export * from "./WebSocketTransport";
+
 export interface Transport {
     readonly type: string;
     url: string;


### PR DESCRIPTION
Exposed `createWebSocket` "protected" function in `WebSocketTransport` class, to allow subclassing it and write additional custom logic for that.

For example, it would then be possible to create a web-socket that is able to count the traffic in bytes for rx and tx, for analytics. However, this is a general enhancement to allow any customization at web-socket level.

Thx! L