### PR TITLE
Exposing WebSocket status

### DIFF
--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.d.ts
@@ -1,0 +1,5 @@
+import {Transport} from "./Transport";
+
+export class WebSocketTransport extends Transport {
+    readonly isWebSocketConnected: boolean;
+}

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
@@ -97,6 +97,10 @@ export class WebSocketTransport extends Transport {
         }
     }
 
+    get isWebSocketConnected() {
+        return this.#webSocketConnected;
+    }
+
     #websocketConnect(context) {
         // We may have multiple attempts to open a WebSocket
         // connection, for example a /meta/connect request that

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/cometd.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export * from "./WebSocketTransport";
+
 export interface Transport {
     readonly type: string;
     url: string;


### PR DESCRIPTION
Hello,
The proposal is to simply expose in read-only the connection status of the web-socket, for analytics and debugging purpose only.
API names can be subject to change, not sure about the standard.
Thx, L