### PR TITLE
Allow CometD JS code to work on Node.JS, service-workers and browser

### DIFF
--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/CallbackPollingTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/CallbackPollingTransport.js
@@ -24,13 +24,13 @@ export class CallbackPollingTransport extends RequestTransport {
     }
 
     jsonpSend(packet) {
-        const head = window.document.getElementsByTagName("head")[0];
-        const script = window.document.createElement("script");
+        const head = globalThis.document.getElementsByTagName("head")[0];
+        const script = globalThis.document.createElement("script");
 
         const callbackName = "_cometd_jsonp_" + this.#jsonp++;
-        window[callbackName] = (responseText) => {
+        globalThis[callbackName] = (responseText) => {
             head.removeChild(script);
-            delete window[callbackName];
+            delete globalThis[callbackName];
             packet.onSuccess(responseText);
         };
 

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/Client.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/Client.js
@@ -36,15 +36,15 @@ function Scheduler() {
         delete _tasks[id];
         return funktion;
     };
-    this.setTimeout = (funktion, delay) => window.setTimeout(funktion, delay);
+    this.setTimeout = (funktion, delay) => globalThis.setTimeout(funktion, delay);
     this.clearTimeout = (id) => {
-        window.clearTimeout(id);
+        globalThis.clearTimeout(id);
     };
 }
 
 /**
  * The scheduler code that will run in the Worker.
- * Workers have a built-in `self` variable similar to `window`.
+ * Workers have a built-in `self` variable similar to `globalThis`.
  */
 function WorkerScheduler() {
     const _tasks = {};
@@ -132,7 +132,7 @@ export class CometD {
     constructor(name) {
         this.#name = name || "default";
         // Initialize transports.
-        if (window.WebSocket) {
+        if (globalThis.WebSocket) {
             this.registerTransport("websocket", new WebSocketTransport());
         }
         this.registerTransport("long-polling", new LongPollingTransport());
@@ -277,13 +277,13 @@ export class CometD {
     }
 
     #log(level, args) {
-        if (window.console) {
-            const logger = window.console[level];
+        if (globalThis.console) {
+            const logger = globalThis.console[level];
             if (CometD.#isFunction(logger)) {
                 const now = new Date();
                 [].splice.call(args, 0, 0, CometD.#zeroPad(now.getHours(), 2) + ":" + CometD.#zeroPad(now.getMinutes(), 2) + ":" +
                     CometD.#zeroPad(now.getSeconds(), 2) + "." + CometD.#zeroPad(now.getMilliseconds(), 3));
-                logger.apply(window.console, args);
+                logger.apply(globalThis.console, args);
             }
         }
     }
@@ -319,7 +319,7 @@ export class CometD {
 
     /**
      * Returns whether the given hostAndPort is cross domain.
-     * The default implementation checks against window.location.host
+     * The default implementation checks against globalThis.location.host
      * but this function can be overridden to make it work in non-browser
      * environments.
      *
@@ -327,9 +327,9 @@ export class CometD {
      * @return whether the given hostAndPort is cross domain
      */
     #isCrossDomain(hostAndPort) {
-        if (window.location && window.location.host) {
+        if (globalThis.location && globalThis.location.host) {
             if (hostAndPort) {
-                return hostAndPort !== window.location.host;
+                return hostAndPort !== globalThis.location.host;
             }
         }
         return false;
@@ -381,15 +381,15 @@ export class CometD {
             }
         }
 
-        if (window.Worker && window.Blob && window.URL && this.#config.useWorkerScheduler) {
+        if (globalThis.Worker && globalThis.Blob && globalThis.URL && this.#config.useWorkerScheduler) {
             let code = WorkerScheduler.toString();
             // Remove the function declaration, the opening brace and the closing brace.
             code = code.substring(code.indexOf("{") + 1, code.lastIndexOf("}"));
-            const blob = new window.Blob([code], {
+            const blob = new globalThis.Blob([code], {
                 type: "application/json"
             });
-            const blobURL = window.URL.createObjectURL(blob);
-            const worker = new window.Worker(blobURL);
+            const blobURL = globalThis.URL.createObjectURL(blob);
+            const worker = new globalThis.Worker(blobURL);
             // Replace setTimeout() and clearTimeout() with the worker implementation.
             this.#scheduler.setTimeout = (funktion, delay) => {
                 const id = this.#scheduler.register(funktion);

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/LongPollingTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/LongPollingTransport.js
@@ -25,7 +25,7 @@ export class LongPollingTransport extends RequestTransport {
     }
 
     #newXMLHttpRequest() {
-        return new window.XMLHttpRequest();
+        return new globalThis.XMLHttpRequest();
     }
 
     #copyContext(xhr) {

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/ReloadExtension.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/ReloadExtension.js
@@ -22,12 +22,12 @@ import {Extension} from "./Extension.js";
  * therefore resuming the existing CometD connection.
  *
  * When the reload() method is called, the state of the CometD
- * connection is stored in the window.sessionStorage object.
+ * connection is stored in the globalThis.sessionStorage object.
  * The reload() method must therefore be called by page unload
  * handlers, often provided by JavaScript toolkits.
  *
  * When the page is (re)loaded, this extension checks the
- * window.sessionStorage and restores the CometD connection,
+ * globalThis.sessionStorage and restores the CometD connection,
  * maintaining the same CometD clientId.
  */
 export class ReloadExtension extends Extension {
@@ -51,7 +51,7 @@ export class ReloadExtension extends Extension {
             this.configure(config);
             const state = JSON.stringify(this.#state);
             this.cometd._debug("Reload extension saving state", state);
-            window.sessionStorage.setItem(this.#name, state);
+            globalThis.sessionStorage.setItem(this.#name, state);
         }
     }
 
@@ -94,7 +94,7 @@ export class ReloadExtension extends Extension {
                     url: this.cometd.getURL()
                 };
 
-                const state = window.sessionStorage.getItem(this.#name);
+                const state = globalThis.sessionStorage.getItem(this.#name);
                 this.cometd._debug("Reload extension found state", state);
                 // Is there a saved handshake response from a prior load?
                 if (state) {
@@ -102,7 +102,7 @@ export class ReloadExtension extends Extension {
                         const oldState = JSON.parse(state);
 
                         // Remove the state, not needed anymore.
-                        window.sessionStorage.removeItem(this.#name);
+                        globalThis.sessionStorage.removeItem(this.#name);
 
                         if (oldState.handshakeResponse && this.#similarState(oldState)) {
                             this.cometd._debug("Reload extension restoring state", oldState);

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/RequestTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/RequestTransport.js
@@ -249,7 +249,7 @@ export class RequestTransport extends Transport {
             try {
                 const state = xhr.readyState;
                 xhr.abort();
-                return state !== window.XMLHttpRequest.UNSENT;
+                return state !== globalThis.XMLHttpRequest.UNSENT;
             } catch (x) {
                 this.debug(x);
             }

--- a/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
+++ b/cometd-javascript/cometd-javascript-common/src/main/webapp/js/cometd/WebSocketTransport.js
@@ -112,7 +112,7 @@ export class WebSocketTransport extends Transport {
 
         try {
             const protocol = this.configuration.protocol;
-            context.webSocket = protocol ? new window.WebSocket(url, protocol) : new window.WebSocket(url);
+            context.webSocket = protocol ? new globalThis.WebSocket(url, protocol) : new globalThis.WebSocket(url);
             this.#connecting = context;
         } catch (x) {
             this.#webSocketSupported = false;
@@ -387,7 +387,7 @@ export class WebSocketTransport extends Transport {
     accept(version, crossDomain, url) {
         this.debug("Transport", this.type, "accept, supported:", this.#webSocketSupported);
         // Using !! to return a boolean (and not the WebSocket object).
-        return this.#webSocketSupported && !!window.WebSocket && this.cometd.websocketEnabled !== false;
+        return this.#webSocketSupported && !!globalThis.WebSocket && this.cometd.websocketEnabled !== false;
     };
 
     send(envelope, metaConnect) {


### PR DESCRIPTION
Hello,
Recent browsers standardized the access to "global" objects (like `setTimeout`, web-socket creation, etc..) with the introduction of `globalThis` symbol: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

With this it won't be required anymore to write conditional code to access the 'global' scope based on the current running environment.

It is a recent addition (~ from 2018), but it will greatly improve the compatibility of the JS code to run in all known environments without requiring manual passing of "global" object.

I've tested it on Node.JS and browser and it doesn't seems to introduce regressions. Obviously, it will change the minimum supported browser version of CometD. MDN says:


Chrome | Edge | Firefox | Opera | Safari | Chrome Android | Firefox for Android | Opera Android | Safari on iOS | Samsung Internet | WebView Android | WebView on iOS | Node.js
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
71 | 79 | 65 | 58 | 12.1 | 71 | 65 | 50 | 12.2 | 10 | 71 | 12.2 | 12

What do you think about this change?
Thanks, L
